### PR TITLE
Date the v6.0.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This repository is the continuation of the original [fondberg/spotcast](https://github.com/fondberg/spotcast) project. For the history of releases prior to v6, see the [original project's releases](https://github.com/fondberg/spotcast/releases).
 
-## v6.0.0 (upcoming)
+## v6.0.0 (2026-07-11)
 
 Spotcast v6 is a complete rewrite of the integration. It requires **Home Assistant 2026.4 or newer**.
 


### PR DESCRIPTION
Sets the release date ahead of tagging v6.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)