### PR TITLE
Port upstream fixes: null search items and items-key playlist counts

### DIFF
--- a/custom_components/spotcast/services/play_media.py
+++ b/custom_components/spotcast/services/play_media.py
@@ -202,7 +202,17 @@ async def async_random_index(account: SpotifyAccount, uri: str) -> int:
         try:
             with suppress_playlist_404_logs():
                 playlist = await account.async_get_playlist(uri)
-            count = playlist["tracks"]["total"]
+            tracks = playlist.get("tracks") or playlist.get("items") or {}
+            count = tracks.get("total")
+            if count is None:
+                LOGGER.warning(
+                    "Could not determine the track count for playlist "
+                    "`%s`. Using a pseudo-random start offset within the "
+                    "first %d tracks.",
+                    uri,
+                    _RANDOM_FALLBACK_ITEMS,
+                )
+                return randint(0, _RANDOM_FALLBACK_ITEMS - 1)
         except SpotifyException as exc:
             if exc.http_status != 404:
                 raise

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -780,7 +780,7 @@ class SpotifyAccount:
             key = f"{item_type}s"
             result[key] = [
                 item
-                for item in search_result[key]["items"]
+                for item in (search_result[key]["items"] or [])
                 if item is not None
             ]
 

--- a/test/services/play_media/test_async_random_index.py
+++ b/test/services/play_media/test_async_random_index.py
@@ -177,3 +177,69 @@ class TestPlaylistOtherSpotifyError(IsolatedAsyncioTestCase):
                 self.mocks["account"],
                 "spotify:playlist:foo",
             )
+
+
+class TestPlaylistWithItemsKeyRandInt(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.randint", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_random: MagicMock):
+
+        mock_random.return_value = 7
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount)
+        }
+
+        self.mocks["account"].async_get_playlist = AsyncMock()
+        self.mocks["account"].async_get_playlist.return_value = {
+            "items": {
+                "total": 53
+            }
+        }
+        self.resut = await async_random_index(
+            self.mocks["account"],
+            "spotify:playlist:foo",
+        )
+
+    def test_received_expected_index(self):
+        self.assertEqual(self.resut, 7)
+
+    def test_randint_called_with_item_count(self):
+        try:
+            self.mocks["account"].async_get_playlist.assert_called()
+        except AssertionError:
+            self.fail()
+
+
+class TestPlaylistWithoutTrackCountRandInt(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.randint", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_random: MagicMock):
+
+        mock_random.return_value = 3
+        self.mock_random = mock_random
+
+        self.mocks = {
+            "account": MagicMock(spec=SpotifyAccount)
+        }
+
+        self.mocks["account"].async_get_playlist = AsyncMock()
+        self.mocks["account"].async_get_playlist.return_value = {
+            "id": "foo"
+        }
+        self.resut = await async_random_index(
+            self.mocks["account"],
+            "spotify:playlist:foo",
+        )
+
+    def test_received_expected_index(self):
+        self.assertEqual(self.resut, 3)
+
+    def test_falls_back_to_default_item_window(self):
+        try:
+            self.mock_random.assert_called_with(
+                0,
+                _RANDOM_FALLBACK_ITEMS - 1,
+            )
+        except AssertionError as exc:
+            self.fail(exc)

--- a/test/spotify/account/test_async_search.py
+++ b/test/spotify/account/test_async_search.py
@@ -94,3 +94,42 @@ class TestSearchQueryWithNoneItems(IsolatedAsyncioTestCase):
 
     def test_none_items_are_stripped(self):
         self.assertEqual(self.result, {"artists": ["foo", "bar"]})
+
+
+class TestSearchQueryWithNullItemList(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch.object(SpotifyAccount, "_async_pager")
+    async def asyncSetUp(self, mock_pager: AsyncMock, mock_store: MagicMock):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "external": MagicMock(spec=PublicSession),
+            "internal": MagicMock(spec=DesktopSession),
+            "pager": mock_pager,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+        )
+        self.account._datasets["profile"].expires_at = time() + 999
+        self.account._datasets["profile"]._data = {
+            "country": "CA"
+        }
+
+        self.query = SearchQuery(
+            search="foo",
+            item_types="artist",
+        )
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            return_value={"artists": {"items": None}}
+        )
+
+        self.result = await self.account.async_search(self.query)
+
+    def test_null_item_list_returns_empty_result(self):
+        self.assertEqual(self.result, {"artists": []})


### PR DESCRIPTION
Ports two community fixes that were pending on the original repository, adapted to the current codebase and credited to their authors:

- **fondberg/spotcast#604** (@iammoen): `async_search` now tolerates a `null` items list from Spotify, not just null entries inside the list.
- **fondberg/spotcast#609** (@superbullock): `async_random_index` accepts playlist payloads carrying the count under `items` instead of `tracks`, and falls back to the pseudo-random 25-track window instead of raising when no count is available (consistent with the editorial-playlist 404 handling).

Both come with tests (571 total, pylint 9.57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)