### PR TITLE
Validate granted OAuth scopes at setup and trigger reauth when missing

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -35,6 +35,24 @@ PLATFORMS = [
 ]
 
 
+def get_missing_scopes(entry: ConfigEntry) -> set[str]:
+    """Returns the required OAuth scopes missing from the entry's
+    public token. OAuth scopes are frozen at consent time, so a scope
+    added in a newer release is absent from tokens authorized before
+    it and the account must reauthenticate to grant it.
+    """
+    token = entry.data.get("external_api", {}).get("token", {})
+    granted = token.get("scope")
+
+    if not granted:
+        # No scope information available. Assume valid rather than
+        # locking the account out.
+        return set()
+
+    granted_scopes = set(granted.replace(",", " ").split())
+    return set(SpotifyAccount.SCOPE) - granted_scopes
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Initial setup of spotcast.
 
@@ -46,6 +64,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if updated_options != entry.options:
         hass.config_entries.async_update_entry(entry, options=updated_options)
+
+    missing_scopes = get_missing_scopes(entry)
+
+    if missing_scopes:
+        raise ConfigEntryAuthFailed(
+            "The Spotify authorization is missing the required scopes "
+            f"`{', '.join(sorted(missing_scopes))}`. Reauthenticate the "
+            "account to grant the new permissions."
+        )
 
     try:
         account = await SpotifyAccount.async_from_config_entry(

--- a/test/test_async_setup_entry.py
+++ b/test/test_async_setup_entry.py
@@ -14,6 +14,12 @@ from custom_components.spotcast import (
 )
 from custom_components.spotcast.spotify import SpotifyAccount
 
+FULL_SCOPE_DATA = {
+    "external_api": {
+        "token": {"scope": " ".join(SpotifyAccount.SCOPE)},
+    },
+}
+
 TEST_MODULE = "custom_components.spotcast"
 
 
@@ -39,6 +45,7 @@ class TestEntryRegistration(IsolatedAsyncioTestCase):
 
         self.mocks["hass"].data = {}
         self.mocks["entry"].entry_id = "foo"
+        self.mocks["entry"].data = FULL_SCOPE_DATA
         self.mocks["entry"].options = {
             "is_default": True,
             "base_refresh_rate": 20,
@@ -94,6 +101,7 @@ class TestDefaultOptionsSet(IsolatedAsyncioTestCase):
 
         self.mocks["hass"].data = {}
         self.mocks["entry"].entry_id = "foo"
+        self.mocks["entry"].data = FULL_SCOPE_DATA
         self.mocks["entry"].options = {
             "is_default": True,
         }
@@ -144,6 +152,7 @@ class TestTokensErrorAtRefresh(IsolatedAsyncioTestCase):
 
         self.mocks["hass"].data = {}
         self.mocks["entry"].entry_id = "foo"
+        self.mocks["entry"].data = FULL_SCOPE_DATA
         self.mocks["entry"].options = {}
         self.mocks["account"].is_default = True
         self.mocks["hass"].config_entries\
@@ -180,6 +189,7 @@ class TestGatewayError(IsolatedAsyncioTestCase):
 
         self.mocks["hass"].data = {}
         self.mocks["entry"].entry_id = "foo"
+        self.mocks["entry"].data = FULL_SCOPE_DATA
         self.mocks["entry"].options = {}
         self.mocks["account"].is_default = True
         self.mocks["hass"].config_entries\
@@ -216,6 +226,7 @@ class TestTokensErrorAtAccountBuild(IsolatedAsyncioTestCase):
 
         self.mocks["hass"].data = {}
         self.mocks["entry"].entry_id = "foo"
+        self.mocks["entry"].data = FULL_SCOPE_DATA
         self.mocks["entry"].options = {}
         self.mocks["account"].is_default = True
         self.mocks["hass"].config_entries\

--- a/test/test_get_missing_scopes.py
+++ b/test/test_get_missing_scopes.py
@@ -1,0 +1,65 @@
+"""Module to test the get_missing_scopes function and its enforcement
+in async_setup_entry"""
+
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import MagicMock
+
+from custom_components.spotcast import (
+    async_setup_entry,
+    get_missing_scopes,
+    HomeAssistant,
+    ConfigEntry,
+    ConfigEntryAuthFailed,
+)
+from custom_components.spotcast.spotify import SpotifyAccount
+
+
+def entry_with_scope(scope) -> MagicMock:
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = "foo"
+    entry.options = {}
+    token = {} if scope is None else {"scope": scope}
+    entry.data = {"external_api": {"token": token}}
+    return entry
+
+
+class TestFullScopes(TestCase):
+
+    def test_no_missing_scopes(self):
+        entry = entry_with_scope(" ".join(SpotifyAccount.SCOPE))
+        self.assertEqual(get_missing_scopes(entry), set())
+
+    def test_comma_separated_scopes_accepted(self):
+        entry = entry_with_scope(",".join(SpotifyAccount.SCOPE))
+        self.assertEqual(get_missing_scopes(entry), set())
+
+
+class TestMissingScopes(TestCase):
+
+    def test_missing_scope_reported(self):
+        granted = [s for s in SpotifyAccount.SCOPE if s != "user-library-modify"]
+        entry = entry_with_scope(" ".join(granted))
+        self.assertEqual(get_missing_scopes(entry), {"user-library-modify"})
+
+
+class TestUnknownScopes(TestCase):
+
+    def test_absent_scope_key_skips_validation(self):
+        entry = entry_with_scope(None)
+        self.assertEqual(get_missing_scopes(entry), set())
+
+    def test_absent_external_api_skips_validation(self):
+        entry = MagicMock(spec=ConfigEntry)
+        entry.data = {}
+        self.assertEqual(get_missing_scopes(entry), set())
+
+
+class TestSetupAbortsOnMissingScopes(IsolatedAsyncioTestCase):
+
+    async def test_auth_failed_raised(self):
+        hass = MagicMock(spec=HomeAssistant)
+        granted = [s for s in SpotifyAccount.SCOPE if s != "user-library-modify"]
+        entry = entry_with_scope(" ".join(granted))
+
+        with self.assertRaises(ConfigEntryAuthFailed):
+            await async_setup_entry(hass, entry)


### PR DESCRIPTION
Fixes #6 (reported upstream as fondberg/spotcast#601 by @vlntnwbr).

At setup, the granted `scope` field of the public token is compared against `SpotifyAccount.SCOPE`. Any missing scope raises `ConfigEntryAuthFailed`, so HA starts the reauth flow and the user re-consents once, picking up the new permissions. Entries without scope information skip validation rather than locking the account out.

This makes scope additions in future releases self-healing instead of producing unexplained 403s for accounts authorized on older versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)