### PR TITLE
Document that the desktop-identity authentication is unofficial

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Spotcast is a Home Assistant custom integration that starts Spotify playback on 
 > [!IMPORTANT]
 > Spotcast requires a **Spotify Premium** account to work.
 
+> [!WARNING]
+> Some Spotcast features need permissions that Spotify does not grant to regular third-party applications. To obtain them, Spotcast authenticates one session under the identity of the official Spotify desktop application (this is why the setup involves a desktop token and a relay server). This method is not officially supported by Spotify and may stop working without notice if Spotify changes its authentication systems. We do our best to adapt quickly when that happens, but temporary breakage is always possible.
+
 > [!NOTE]
 > This repository is the continuation of the original [fondberg/spotcast](https://github.com/fondberg/spotcast) project, created by Niklas Fondberg ([@fondberg](https://github.com/fondberg)) and maintained through v5 and the v6 rewrite by Felix Cusson ([@fcusson](https://github.com/fcusson)). Development now happens here, starting with the v6 release.
 

--- a/docs/config/spotcast_configuration.md
+++ b/docs/config/spotcast_configuration.md
@@ -6,6 +6,9 @@ This guide walks you through the setup of Spotcast in Home Assistant. The setup 
 2. Start a small relay server on your computer (only needed during setup).
 3. Run the Spotcast config flow in Home Assistant.
 
+> [!WARNING]
+> Why is a relay server needed at all? Some Spotcast features require permissions that Spotify only grants to its own applications. During setup, Spotcast therefore authenticates one session under the identity of the official Spotify desktop application, and the relay server is needed to hand that authorization over to Home Assistant. Because this method is not officially supported by Spotify, it may stop working without notice if Spotify changes its authentication systems.
+
 ## Prerequisites
 
 - A **Spotify Premium** account.


### PR DESCRIPTION
Adds a transparent warning to the README and the configuration guide: Spotcast obtains elevated permissions by authenticating a session under the official Spotify desktop application's identity, which Spotify does not officially support and may break without notice. Also explains, in the guide, why the relay server exists at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)