### PR TITLE
Device lifecycle: UI deletion, stale-device garbage collection

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.const import Platform
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN
 from .services import ServiceHandler
@@ -110,6 +111,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_setup_websocket(hass)
 
     return True
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device_entry: DeviceEntry,
+) -> bool:
+    """Allows removing a device from the UI unless Spotify currently
+    reports it as an available Spotify Connect device."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id) or {}
+    account = entry_data.get("account")
+
+    if account is None:
+        return True
+
+    active_ids = {device["id"] for device in account.devices}
+
+    return not any(
+        identifier in active_ids
+        for domain, identifier in device_entry.identifiers
+        if domain == DOMAIN
+    )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/spotcast/media_player/device_manager.py
+++ b/custom_components/spotcast/media_player/device_manager.py
@@ -6,6 +6,7 @@ Classes:
 """
 
 from logging import getLogger
+from time import time
 
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import async_get as async_get_dr
@@ -47,6 +48,8 @@ class DeviceManager:
         "Echo Speaker",
     )
 
+    STALE_DEVICE_TIMEOUT = 7 * 24 * 3600
+
     def __init__(
         self,
         account: SpotifyAccount,
@@ -55,6 +58,7 @@ class DeviceManager:
 
         self.tracked_devices: dict[str, SpotifyDevice] = {}
         self.unavailable_devices: dict[str, SpotifyDevice] = {}
+        self.unavailable_since: dict[str, float] = {}
 
         self._account = account
         self.async_add_entities = async_add_entitites
@@ -94,10 +98,11 @@ class DeviceManager:
             device = self.tracked_devices.pop(id)
 
             if device.device_data["type"] in self.DELETE_ON_UNAVAILABLE:
-                device.async_remove(force_remove=True)
+                await device.async_remove(force_remove=True)
                 self.remove_device(device.device_info["identifiers"])
             else:
                 self.unavailable_devices[id] = device
+                self.unavailable_since[id] = time()
 
         for id, device in current_devices.items():
 
@@ -121,6 +126,7 @@ class DeviceManager:
                     self._account.name,
                 )
                 self.tracked_devices[id] = self.unavailable_devices.pop(id)
+                self.unavailable_since.pop(id, None)
                 self.tracked_devices[id].is_unavailable = False
 
             elif (
@@ -151,6 +157,43 @@ class DeviceManager:
                 device.playback_state = playback_state
             else:
                 device.playback_state = {}
+
+        await self.async_purge_stale_devices()
+
+    async def async_purge_stale_devices(self):
+        """Removes devices that have been unavailable for longer than
+        the grace period. Spotify session devices (e.g. Jams) get a
+        new id every session and would otherwise accumulate forever.
+        """
+        now = time()
+
+        for id in list(self.unavailable_devices):
+
+            elapsed = now - self.unavailable_since.get(id, now)
+
+            if elapsed < self.STALE_DEVICE_TIMEOUT:
+                continue
+
+            device = self.unavailable_devices.pop(id)
+            self.unavailable_since.pop(id, None)
+
+            LOGGER.info(
+                "Removing device `%s` for account `%s`. Unavailable for "
+                "more than %d days",
+                device.name,
+                self._account.name,
+                self.STALE_DEVICE_TIMEOUT // 86400,
+            )
+
+            await device.async_remove(force_remove=True)
+
+            try:
+                self.remove_device(device.device_info["identifiers"])
+            except KeyError:
+                LOGGER.debug(
+                    "Device `%s` was already absent from the registry",
+                    device.name,
+                )
 
     def remove_device(
             self,

--- a/test/media_player/device_manager/test_async_purge_stale_devices.py
+++ b/test/media_player/device_manager/test_async_purge_stale_devices.py
@@ -1,0 +1,90 @@
+"""Module to test the async_purge_stale_devices method"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.media_player.device_manager import (
+    DeviceManager,
+    SpotifyDevice,
+    SpotifyAccount,
+)
+
+TEST_MODULE = "custom_components.spotcast.media_player.device_manager"
+
+
+def build_manager() -> tuple[DeviceManager, MagicMock]:
+    account = MagicMock(spec=SpotifyAccount)
+    account.name = "Dummy Account"
+    manager = DeviceManager(account, MagicMock())
+    device = MagicMock(spec=SpotifyDevice)
+    device.name = "Old Jam Device"
+    device.device_info = {"identifiers": {("spotcast", "foo")}}
+    device.async_remove = AsyncMock()
+    manager.unavailable_devices["foo"] = device
+    manager.remove_device = MagicMock()
+    return manager, device
+
+
+class TestStaleDevicePurged(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.time", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_time: MagicMock):
+        self.manager, self.device = build_manager()
+        self.manager.unavailable_since["foo"] = 1_000
+        mock_time.return_value = (
+            1_000 + DeviceManager.STALE_DEVICE_TIMEOUT + 1
+        )
+        await self.manager.async_purge_stale_devices()
+
+    def test_entity_removed(self):
+        try:
+            self.device.async_remove.assert_awaited_with(force_remove=True)
+        except AssertionError as exc:
+            self.fail(exc)
+
+    def test_registry_entry_removed(self):
+        try:
+            self.manager.remove_device.assert_called_with(
+                {("spotcast", "foo")}
+            )
+        except AssertionError as exc:
+            self.fail(exc)
+
+    def test_device_no_longer_tracked(self):
+        self.assertNotIn("foo", self.manager.unavailable_devices)
+        self.assertNotIn("foo", self.manager.unavailable_since)
+
+
+class TestFreshDeviceKept(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.time", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_time: MagicMock):
+        self.manager, self.device = build_manager()
+        self.manager.unavailable_since["foo"] = 1_000
+        mock_time.return_value = 1_000 + 60
+        await self.manager.async_purge_stale_devices()
+
+    def test_entity_not_removed(self):
+        try:
+            self.device.async_remove.assert_not_called()
+        except AssertionError as exc:
+            self.fail(exc)
+
+    def test_device_still_tracked(self):
+        self.assertIn("foo", self.manager.unavailable_devices)
+
+
+class TestMissingRegistryEntryTolerated(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.time", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_time: MagicMock):
+        self.manager, self.device = build_manager()
+        self.manager.unavailable_since["foo"] = 1_000
+        self.manager.remove_device.side_effect = KeyError("gone")
+        mock_time.return_value = (
+            1_000 + DeviceManager.STALE_DEVICE_TIMEOUT + 1
+        )
+        await self.manager.async_purge_stale_devices()
+
+    def test_device_no_longer_tracked(self):
+        self.assertNotIn("foo", self.manager.unavailable_devices)

--- a/test/test_async_remove_config_entry_device.py
+++ b/test/test_async_remove_config_entry_device.py
@@ -1,0 +1,61 @@
+"""Module to test the async_remove_config_entry_device function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from custom_components.spotcast import (
+    async_remove_config_entry_device,
+    HomeAssistant,
+    ConfigEntry,
+    DOMAIN,
+)
+from custom_components.spotcast.spotify import SpotifyAccount
+
+
+def build_mocks(active_ids: list[str], identifiers: set) -> dict:
+    mocks = {
+        "hass": MagicMock(spec=HomeAssistant),
+        "entry": MagicMock(spec=ConfigEntry),
+        "account": MagicMock(spec=SpotifyAccount),
+        "device": MagicMock(spec=DeviceEntry),
+    }
+    mocks["entry"].entry_id = "12345"
+    mocks["account"].devices = [{"id": x} for x in active_ids]
+    mocks["device"].identifiers = identifiers
+    mocks["hass"].data = {
+        DOMAIN: {"12345": {"account": mocks["account"]}}
+    }
+    return mocks
+
+
+class TestStaleDeviceRemoval(IsolatedAsyncioTestCase):
+
+    async def test_absent_device_can_be_removed(self):
+        mocks = build_mocks(["foo"], {(DOMAIN, "bar")})
+        result = await async_remove_config_entry_device(
+            mocks["hass"], mocks["entry"], mocks["device"],
+        )
+        self.assertTrue(result)
+
+
+class TestActiveDeviceRemoval(IsolatedAsyncioTestCase):
+
+    async def test_active_device_cannot_be_removed(self):
+        mocks = build_mocks(["foo"], {(DOMAIN, "foo")})
+        result = await async_remove_config_entry_device(
+            mocks["hass"], mocks["entry"], mocks["device"],
+        )
+        self.assertFalse(result)
+
+
+class TestUnloadedAccountRemoval(IsolatedAsyncioTestCase):
+
+    async def test_removal_allowed_without_account(self):
+        mocks = build_mocks(["foo"], {(DOMAIN, "foo")})
+        mocks["hass"].data = {}
+        result = await async_remove_config_entry_device(
+            mocks["hass"], mocks["entry"], mocks["device"],
+        )
+        self.assertTrue(result)


### PR DESCRIPTION
Fixes #5 (reported upstream as fondberg/spotcast#608 by @geoffoxholm).

- `async_remove_config_entry_device`: HA now shows the delete button on Spotcast devices; removal is allowed unless Spotify currently reports the device as available.
- `DeviceManager` garbage-collects devices unavailable for more than 7 days, so Jam-session devices (new Spotify id every session) no longer accumulate forever.
- Bug fix found along the way: `Entity.async_remove` was called without `await` in the delete-on-unavailable path, so Web Player/Echo cleanup never actually ran.

Ephemeral-device detection (skipping Jam devices at creation) stays open in #5; it needs payload samples from an affected install before choosing a reliable signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)