### PR TITLE
play_media: accept a context URI in track_context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ venv.bak/
 .vscode/
 config/*
 test/live_testing.py
+.claude/

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Playback actions accept a common `data` section. Here is a list of the common op
 | `shuffle`       | `bool`                    | `null`  | Sets the playback to shuffle if `True`. Kept unchanged if `null`.                                                    |
 | `limit`         | `positive_int`            | `null`  | The maximum number of items retrieved from a Spotify API endpoint. Retrieves all items if `null`.                    |
 | `random`        | `bool`                    | `False` | Starts the context playback at a random item. Only available for albums, playlists and custom contexts.              |
-| `track_context` | `track \| album`          | `album` | Sets the context of a track. With `album`, the rest of the album plays after the song ends; with `track`, playback stops. |
+| `track_context` | `track \| album \| context URI` | `album` | Sets the context of a track. With `album`, the rest of the album plays after the song ends; with `track`, playback stops; with an album or playlist URI (e.g. `spotify:playlist:xxxx`), the track plays inside that context and the context continues afterwards. The track must be part of the context. |
 
 ## Entities
 

--- a/custom_components/spotcast/services/play_media.py
+++ b/custom_components/spotcast/services/play_media.py
@@ -80,8 +80,24 @@ async def async_play_media(hass: HomeAssistant, call: ServiceCall):
     if uri is None:
         pass
     elif uri.startswith("spotify:track:"):
-        if extras.get("track_context") == "track":
+        track_context = extras.get("track_context")
+        if track_context == "track":
             LOGGER.debug("Using track context")
+        elif (
+            isinstance(track_context, str)
+            and track_context.startswith("spotify:")
+        ):
+            uri, index = await async_context_index(
+                account,
+                track_context,
+                uri,
+            )
+            LOGGER.debug(
+                "Switching context to `%s`, with offset %d",
+                uri,
+                index,
+            )
+            extras["offset"] = index
         else:
             uri, index = await async_track_index(account, uri)
             LOGGER.debug(
@@ -179,6 +195,55 @@ async def async_track_index(
     album_songs = [x["uri"] for x in album_info["tracks"]["items"]]
 
     return album_uri, album_songs.index(uri)
+
+
+async def async_context_index(
+    account: SpotifyAccount,
+    context_uri: str,
+    track_uri: str,
+) -> tuple[str, int]:
+    """Returns the context uri and the index of a track within it
+
+    Args:
+        - account(SpotifyAccount): the account used to fetch context
+            information
+        - context_uri(str): an album or playlist URI to play the
+            track in
+        - track_uri(str): the track URI to locate in the context
+
+    Returns:
+        - tuple[str, int]: the context uri and the index of the track
+            within the context
+
+    Raises:
+        - ServiceValidationError: when the context type is not
+            supported or the track is not part of the context
+    """
+    context_type = context_uri.split(":")[1]
+
+    if context_type == "album":
+        album = await account.async_get_album(context_uri)
+        track_uris = [x["uri"] for x in album["tracks"]["items"]]
+    elif context_type == "playlist":
+        items = await account.async_get_playlist_tracks(context_uri)
+        track_uris = [
+            x["track"]["uri"]
+            for x in items
+            if x.get("track") is not None
+        ]
+    else:
+        raise ServiceValidationError(
+            f"`{context_uri}` is not a valid track context. Provide an "
+            "album or playlist URI."
+        )
+
+    if track_uri not in track_uris:
+        raise ServiceValidationError(
+            f"Track `{track_uri}` is not part of the context "
+            f"`{context_uri}`"
+        )
+
+    return context_uri, track_uris.index(track_uri)
 
 
 async def async_random_index(account: SpotifyAccount, uri: str) -> int:

--- a/docs/services/play_media.md
+++ b/docs/services/play_media.md
@@ -21,7 +21,7 @@ Let the user select a compatible device on which to start the playback. **_Must 
 
 ### `uri` (str)
 
-The Spotify URI or URL used for the context in the playback. In the case of a track URI, the context will become the album of the track, but set to the correct position of the track in the album.
+The Spotify URI or URL used for the context in the playback. In the case of a track URI, the context will become the album of the track, but set to the correct position of the track in the album. This behavior can be changed with the `track_context` option in `data`: `track` plays only the song, `album` (default) plays the rest of the album afterwards, and an album or playlist URI (e.g. `spotify:playlist:xxxx`) plays the track inside that context, continuing with the context afterwards. The track must be part of the provided context.
 
 ### `spotify_account` (str)
 

--- a/test/services/play_media/test_async_context_index.py
+++ b/test/services/play_media/test_async_context_index.py
@@ -1,0 +1,73 @@
+"""Module to test the async_context_index function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock
+
+from custom_components.spotcast.services.play_media import (
+    async_context_index,
+    SpotifyAccount,
+    ServiceValidationError,
+)
+
+
+class TestAlbumContext(IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.account = MagicMock(spec=SpotifyAccount)
+        self.account.async_get_album = AsyncMock(return_value={
+            "tracks": {"items": [
+                {"uri": "spotify:track:aaa"},
+                {"uri": "spotify:track:bbb"},
+            ]}
+        })
+        self.result = await async_context_index(
+            self.account,
+            "spotify:album:foo",
+            "spotify:track:bbb",
+        )
+
+    def test_context_and_index_returned(self):
+        self.assertEqual(self.result, ("spotify:album:foo", 1))
+
+
+class TestPlaylistContext(IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.account = MagicMock(spec=SpotifyAccount)
+        self.account.async_get_playlist_tracks = AsyncMock(return_value=[
+            {"track": {"uri": "spotify:track:aaa"}},
+            {"track": None},
+            {"track": {"uri": "spotify:track:bbb"}},
+        ])
+        self.result = await async_context_index(
+            self.account,
+            "spotify:playlist:foo",
+            "spotify:track:bbb",
+        )
+
+    def test_context_and_index_returned(self):
+        self.assertEqual(self.result, ("spotify:playlist:foo", 1))
+
+
+class TestInvalidContext(IsolatedAsyncioTestCase):
+
+    async def test_unsupported_context_raises(self):
+        account = MagicMock(spec=SpotifyAccount)
+        with self.assertRaises(ServiceValidationError):
+            await async_context_index(
+                account,
+                "spotify:artist:foo",
+                "spotify:track:bbb",
+            )
+
+    async def test_track_absent_from_context_raises(self):
+        account = MagicMock(spec=SpotifyAccount)
+        account.async_get_album = AsyncMock(return_value={
+            "tracks": {"items": [{"uri": "spotify:track:aaa"}]}
+        })
+        with self.assertRaises(ServiceValidationError):
+            await async_context_index(
+                account,
+                "spotify:album:foo",
+                "spotify:track:zzz",
+            )


### PR DESCRIPTION
Fixes #7 (fondberg/spotcast#551, original attempt in fondberg/spotcast#555 by @sermayoral).

`track_context` now accepts an album or playlist URI in addition to `track | album`. The track's position inside the context is resolved and validated (clear ServiceValidationError when the track is absent or the context type is unsupported). Docs and README updated; 4 new test classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)