### PR TITLE
Harden reauth against legacy/malformed entries (#571)

### DIFF
--- a/custom_components/spotcast/config_flow_classes/config_flow_handler.py
+++ b/custom_components/spotcast/config_flow_classes/config_flow_handler.py
@@ -257,22 +257,28 @@ class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Confirm reauth dialog."""
         reauth_entry = self._get_reauth_entry()
+        external_api = reauth_entry.data.get("external_api", {})
 
         if user_input is None:
             return self.async_show_form(
                 step_id="reauth_confirm",
                 description_placeholders={
-                    "account": reauth_entry.data["external_api"]["id"]
+                    "account": external_api.get("id", "unknown account")
                 },
                 errors={},
             )
 
+        # `auth_implementation` may be absent on entries created by older
+        # versions with a different data layout. Falling back to the
+        # implementation picker without a preselected implementation lets the
+        # user recover instead of hitting a config flow 500 error.
+        auth_implementation = external_api.get("auth_implementation")
+
+        if auth_implementation is None:
+            return await self.async_step_pick_implementation()
+
         return await self.async_step_pick_implementation(
-            user_input={
-                "implementation": reauth_entry.data["external_api"][
-                    "auth_implementation"
-                ]
-            }
+            user_input={"implementation": auth_implementation}
         )
 
     @staticmethod

--- a/test/config_flow_classes/config_flow_handler/test_async_step_reauth_confirm.py
+++ b/test/config_flow_classes/config_flow_handler/test_async_step_reauth_confirm.py
@@ -102,3 +102,83 @@ class TestSecondtCall(IsolatedAsyncioTestCase):
             )
         except AssertionError:
             self.fail()
+
+
+class TestMalformedEntryFirstCall(IsolatedAsyncioTestCase):
+    """A legacy/malformed entry missing `external_api` must show the form
+    instead of raising a KeyError (which surfaced as a config flow 500)."""
+
+    @patch.object(SpotcastFlowHandler, "async_step_pick_implementation")
+    @patch.object(SpotcastFlowHandler, "async_show_form", new_callable=MagicMock)
+    @patch.object(SpotcastFlowHandler, "_get_reauth_entry", new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_entry: MagicMock,
+            mock_form: MagicMock,
+            mock_impl: AsyncMock
+    ):
+
+        mock_entry.return_value = MagicMock(spec=ConfigEntry)
+
+        self.mocks = {
+            "entry": mock_entry.return_value,
+            "form": mock_form,
+            "implementation": mock_impl
+        }
+
+        self.mocks["entry"].data = {}
+
+        self.handler = SpotcastFlowHandler()
+
+        await self.handler.async_step_reauth_confirm()
+
+    def test_show_form_called_with_placeholder(self):
+        try:
+            self.mocks["form"].assert_called_with(
+                step_id="reauth_confirm",
+                description_placeholders={
+                    "account": "unknown account"
+                },
+                errors={},
+            )
+        except AssertionError:
+            self.fail()
+
+
+class TestMalformedEntrySecondCall(IsolatedAsyncioTestCase):
+    """A legacy/malformed entry missing `auth_implementation` must fall back
+    to the implementation picker rather than raising a KeyError."""
+
+    @patch.object(SpotcastFlowHandler, "async_step_pick_implementation")
+    @patch.object(SpotcastFlowHandler, "async_show_form", new_callable=MagicMock)
+    @patch.object(SpotcastFlowHandler, "_get_reauth_entry", new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_entry: MagicMock,
+            mock_form: MagicMock,
+            mock_impl: AsyncMock
+    ):
+
+        mock_entry.return_value = MagicMock(spec=ConfigEntry)
+
+        self.mocks = {
+            "entry": mock_entry.return_value,
+            "form": mock_form,
+            "implementation": mock_impl
+        }
+
+        self.mocks["entry"].data = {
+            "external_api": {
+                "id": "dummy_id"
+            }
+        }
+
+        self.handler = SpotcastFlowHandler()
+
+        await self.handler.async_step_reauth_confirm({})
+
+    def test_pick_implementation_called_without_input(self):
+        try:
+            self.mocks["implementation"].assert_called_once_with()
+        except AssertionError:
+            self.fail()


### PR DESCRIPTION
## Summary
The reauth confirm step read `reauth_entry.data["external_api"]["id"]` and `["auth_implementation"]` with unguarded subscripts. An entry created under an older data layout can be missing those keys, which raises a `KeyError` while Home Assistant builds the flow step. That surfaces to the user as **"Config flow could not be loaded: 500 Internal Server Error"** and leaves the account stuck, unable to re-authenticate.

This is the residual form of upstream [fondberg/spotcast#571](https://github.com/fondberg/spotcast/issues/571): the literal "Reconfigure" trigger is already gone in v6 (no `async_step_reconfigure`), but the same unguarded access still exists on the reauth path.

## Change
`async_step_reauth_confirm` now uses defensive `.get()` access:
- Missing `external_api`/`id` -> the confirmation dialog shows an "unknown account" placeholder instead of raising.
- Missing `auth_implementation` -> fall back to `async_step_pick_implementation()` with no preselected implementation, so the user picks one and recovers.

## Tests
Added two cases to `test_async_step_reauth_confirm.py`: an entry with no `external_api` (shows the form), and an entry missing `auth_implementation` (falls back to the picker). Full suite green (613 tests), pylint 9.59.

Fixes fondberg/spotcast#571

🤖 Generated with [Claude Code](https://claude.com/claude-code)