### PR TITLE
Resume transfer_playback at the track uri instead of paginating (#582)

### DIFF
--- a/custom_components/spotcast/services/transfer_playback.py
+++ b/custom_components/spotcast/services/transfer_playback.py
@@ -11,11 +11,9 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.util.read_only_dict import ReadOnlyDict
 from homeassistant.exceptions import ServiceValidationError
 import voluptuous as vol
-from spotipy import SpotifyException
 
 
 from custom_components.spotcast.spotify.account import SpotifyAccount
-from custom_components.spotcast.spotify.utils import suppress_playlist_404_logs
 from custom_components.spotcast.services.play_media import (
     async_play_media,
     async_track_index,
@@ -124,65 +122,29 @@ async def async_rebuild_playback(
         return call_data
 
     current_item = last_playback_state["item"]
-    track_index = 0
 
     # set the offset according to the context type
     if context_type == "album":
+        track_index = 0
         try:
             track_index = await async_track_index(account, current_item["uri"])
             track_index = track_index[1] - 1
         except ValueError:
             pass
+        call_data["data"]["offset"] = track_index
     # change the context to the episode if context is show
     elif context_type == "show":
         call_data["spotify_uri"] = current_item["uri"]
-
-    # all remaining case that rely on fetching a list of items and
-    # finding the current uri in the list
+        call_data["data"]["offset"] = 0
+    # start the context directly at the current track's uri. This avoids
+    # paginating the whole context just to compute a numeric index, which
+    # is what made transfer_playback take up to a minute on large playlists
+    # (see #582).
     elif context_type in ("playlist", "collection"):
-
-        tracks = await _async_context_track_uris(
-            account, context_type, context_uri
-        )
-
-        try:
-            track_index = tracks.index(current_item["uri"])
-        except ValueError:
-            pass
-
-    if context_type == "artist":
+        call_data["data"]["offset"] = current_item["uri"]
+    elif context_type == "artist":
         call_data["data"]["offset"] = None
     else:
-        call_data["data"]["offset"] = track_index
+        call_data["data"]["offset"] = 0
 
     return call_data
-
-
-async def _async_context_track_uris(
-    account: SpotifyAccount,
-    context_type: str,
-    context_uri: str,
-) -> list[str]:
-    """Returns the track uris of a playlist or collection context.
-
-    Spotify 404s on its own editorial/algorithmic playlists, so treat
-    that as an empty track list and let the caller rebuild playback from
-    the first track. See issues #570 and #599.
-    """
-    if context_type != "playlist":
-        return await account.async_liked_songs()
-
-    try:
-        with suppress_playlist_404_logs():
-            tracks = await account.async_get_playlist_tracks(context_uri)
-        return [x["track"]["uri"] for x in tracks]
-    except SpotifyException as exc:
-        if exc.http_status != 404:
-            raise
-        LOGGER.warning(
-            "Spotify returned 404 for playlist `%s` (likely a Spotify "
-            "editorial/algorithmic playlist no longer exposed through the "
-            "Web API). Rebuilding playback from the first track.",
-            context_uri,
-        )
-        return []

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -855,7 +855,7 @@ class SpotifyAccount:
         device_id: str,
         context_uri: str = None,
         uris: list[str] = None,
-        offset: int = None,
+        offset: int | str = None,
         position: int = None,
         **_,
     ) -> None:
@@ -867,8 +867,10 @@ class SpotifyAccount:
                 Defaults to None.
             uris(list[str], optional): List of uris to play in a
                 custom context. Defaults to None.
-            offset(int, optional): The offset to used in starting media
-                from a context
+            offset(int | str, optional): Where to start within the
+                context. An int is treated as a track position; a track
+                uri string starts at that track directly (avoids having
+                to resolve its position).
             position(int, optional): The position in the song to start
                 at the media.
 
@@ -895,7 +897,10 @@ class SpotifyAccount:
         )
 
         if offset is not None:
-            offset = {"position": offset}
+            if isinstance(offset, str):
+                offset = {"uri": offset}
+            else:
+                offset = {"position": offset}
 
         if position is not None:
             position = int(position * 1000)

--- a/test/services/transfer_playback/test_async_rebuild_playback.py
+++ b/test/services/transfer_playback/test_async_rebuild_playback.py
@@ -3,8 +3,6 @@
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock, patch
 
-from spotipy import SpotifyException
-
 from custom_components.spotcast.services.transfer_playback import (
     async_rebuild_playback,
     SpotifyAccount,
@@ -236,7 +234,10 @@ class TestCurrentItemNotPartOfAlbumContext(IsolatedAsyncioTestCase):
         )
 
 
-class TestCurrentItemPartOfPlaylist(IsolatedAsyncioTestCase):
+class TestPlaylistContext(IsolatedAsyncioTestCase):
+    """A playlist context resumes directly at the current track's uri,
+    without paginating the whole playlist to find its numeric index. This
+    is what fixes the slow transfer on large playlists (see #582)."""
 
     @patch(f"{TEST_MODULE}.async_track_index")
     async def asyncSetUp(self, mock_index: AsyncMock):
@@ -262,13 +263,7 @@ class TestCurrentItemPartOfPlaylist(IsolatedAsyncioTestCase):
             }
         }
 
-        self.mocks["account"].async_get_playlist_tracks = AsyncMock(
-            return_value=[
-                {"track": {"uri": "spotify:track:foo"}},
-                {"track": {"uri": "spotify:track:bar"}},
-                {"track": {"uri": "spotify:track:baz"}},
-            ]
-        )
+        self.mocks["account"].async_get_playlist_tracks = AsyncMock()
 
         self.call_data = {
             "media_player": {
@@ -297,7 +292,7 @@ class TestCurrentItemPartOfPlaylist(IsolatedAsyncioTestCase):
                 },
                 "spotify_uri": "spotify:playlist:foo",
                 "data": {
-                    "offset": 1,
+                    "offset": "spotify:track:bar",
                     "shuffle": True,
                     "repeat": "context",
                     "position": 5
@@ -311,8 +306,18 @@ class TestCurrentItemPartOfPlaylist(IsolatedAsyncioTestCase):
         except AssertionError:
             self.fail()
 
+    def test_playlist_not_fetched(self):
+        try:
+            self.mocks["account"].async_get_playlist_tracks\
+                .assert_not_called()
+        except AssertionError:
+            self.fail()
 
-class TestCurrentItemNotPartOfPlaylist(IsolatedAsyncioTestCase):
+
+class TestEditorialPlaylistContext(IsolatedAsyncioTestCase):
+    """Editorial/algorithmic playlists (37i9) 404 on the Web API, so the
+    old index-based rebuild had to degrade. Resuming at the track uri needs
+    no playlist read, so it works for editorial playlists too (#570, #582)."""
 
     @patch(f"{TEST_MODULE}.async_track_index")
     async def asyncSetUp(self, mock_index: AsyncMock):
@@ -327,7 +332,7 @@ class TestCurrentItemNotPartOfPlaylist(IsolatedAsyncioTestCase):
             "repeat_state": "context",
             "shuffle_state": True,
             "context": {
-                "uri": "spotify:playlist:foo",
+                "uri": "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
                 "type": "playlist"
             },
             "item": {
@@ -338,13 +343,7 @@ class TestCurrentItemNotPartOfPlaylist(IsolatedAsyncioTestCase):
             }
         }
 
-        self.mocks["account"].async_get_playlist_tracks = AsyncMock(
-            return_value=[
-                {"track": {"uri": "spotify:track:foo"}},
-                {"track": {"uri": "spotify:track:bar"}},
-                {"track": {"uri": "spotify:track:baz"}},
-            ]
-        )
+        self.mocks["account"].async_get_playlist_tracks = AsyncMock()
 
         self.call_data = {
             "media_player": {
@@ -362,33 +361,29 @@ class TestCurrentItemNotPartOfPlaylist(IsolatedAsyncioTestCase):
             self.mocks["account"],
         )
 
-    def test_returned_expected_call_data(self):
+    def test_offset_is_track_uri(self):
         self.assertEqual(
-            self.result,
-            {
-                "media_player": {
-                    "entity_id": [
-                        "media_player.foo"
-                    ]
-                },
-                "spotify_uri": "spotify:playlist:foo",
-                "data": {
-                    "offset": 1,
-                    "shuffle": True,
-                    "repeat": "context",
-                    "position": 5
-                }
-            }
+            self.result["data"]["offset"],
+            "spotify:track:bar",
         )
 
-    def test_track_index_not_called(self):
+    def test_playlist_uri_kept(self):
+        self.assertEqual(
+            self.result["spotify_uri"],
+            "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
+        )
+
+    def test_playlist_not_fetched(self):
         try:
-            self.mocks["index"].assert_not_called()
+            self.mocks["account"].async_get_playlist_tracks\
+                .assert_not_called()
         except AssertionError:
             self.fail()
 
 
-class TestCurrentItemPartOfCollection(IsolatedAsyncioTestCase):
+class TestCollectionContext(IsolatedAsyncioTestCase):
+    """The liked-songs (collection) context resumes at the current track's
+    uri, without fetching the whole liked-songs library."""
 
     @patch(f"{TEST_MODULE}.async_track_index")
     async def asyncSetUp(self, mock_index: AsyncMock):
@@ -415,13 +410,7 @@ class TestCurrentItemPartOfCollection(IsolatedAsyncioTestCase):
             }
         }
 
-        self.mocks["account"].async_liked_songs = AsyncMock(
-            return_value=[
-                "spotify:track:foo",
-                "spotify:track:bar",
-                "spotify:track:baz",
-            ]
-        )
+        self.mocks["account"].async_liked_songs = AsyncMock()
 
         self.call_data = {
             "media_player": {
@@ -448,7 +437,7 @@ class TestCurrentItemPartOfCollection(IsolatedAsyncioTestCase):
                 },
                 "spotify_uri": "spotify:user:dummy:collection",
                 "data": {
-                    "offset": 1,
+                    "offset": "spotify:track:bar",
                     "shuffle": True,
                     "repeat": "context",
                     "position": 31.415
@@ -462,79 +451,9 @@ class TestCurrentItemPartOfCollection(IsolatedAsyncioTestCase):
         except AssertionError:
             self.fail()
 
-
-class TestCurrentItemNotPartOfCollection(IsolatedAsyncioTestCase):
-
-    @patch(f"{TEST_MODULE}.async_track_index")
-    async def asyncSetUp(self, mock_index: AsyncMock):
-
-        self.mocks = {
-            "account": MagicMock(spec=SpotifyAccount),
-            "index": mock_index,
-        }
-
-        self.mocks["account"].async_last_playback_state = AsyncMock()
-        self.mocks["account"].async_last_playback_state.return_value = {
-            "repeat_state": "context",
-            "shuffle_state": True,
-            "context": {
-                "uri": "spotify:user:dummy:collection",
-                "type": "collection"
-            },
-            "item": {
-                "album": {
-                    "uri": "spotify:album:baz"
-                },
-                "uri": "spotify:track:bar"
-            }
-        }
-
-        self.mocks["account"].async_liked_songs = AsyncMock(
-            return_value=[
-                {"uri": "spotify:track:foo"},
-                {"uri": "spotify:track:far"},
-                {"uri": "spotify:track:baz"},
-            ]
-        )
-
-        self.call_data = {
-            "media_player": {
-                "entity_id": [
-                    "media_player.foo"
-                ]
-            },
-            "data": {
-                "position": 5
-            }
-        }
-
-        self.result = await async_rebuild_playback(
-            self.call_data,
-            self.mocks["account"],
-        )
-
-    def test_returned_expected_call_data(self):
-        self.assertEqual(
-            self.result,
-            {
-                "media_player": {
-                    "entity_id": [
-                        "media_player.foo"
-                    ]
-                },
-                "spotify_uri": "spotify:user:dummy:collection",
-                "data": {
-                    "offset": 0,
-                    "shuffle": True,
-                    "repeat": "context",
-                    "position": 5
-                }
-            }
-        )
-
-    def test_track_index_not_called(self):
+    def test_liked_songs_not_fetched(self):
         try:
-            self.mocks["index"].assert_not_called()
+            self.mocks["account"].async_liked_songs.assert_not_called()
         except AssertionError:
             self.fail()
 
@@ -564,14 +483,6 @@ class TestUnknownContentType(IsolatedAsyncioTestCase):
                 "uri": "spotify:track:bar"
             }
         }
-
-        self.mocks["account"].async_liked_songs = AsyncMock(
-            return_value=[
-                {"uri": "spotify:track:foo"},
-                {"uri": "spotify:track:far"},
-                {"uri": "spotify:track:baz"},
-            ]
-        )
 
         self.call_data = {
             "media_player": {
@@ -675,62 +586,3 @@ class TestArtistContext(IsolatedAsyncioTestCase):
 
     def test_offset_removed(self):
         self.assertIsNone(self.result["data"]["offset"])
-
-
-class TestPlaylistContextNotFound(IsolatedAsyncioTestCase):
-    """Spotify 404s on its own editorial/algorithmic playlists. The
-    playback rebuild must degrade to the first track (offset 0) instead
-    of raising. See issues #570 and #599."""
-
-    @patch(f"{TEST_MODULE}.async_track_index")
-    async def asyncSetUp(self, mock_index: AsyncMock):
-
-        self.mocks = {
-            "account": MagicMock(spec=SpotifyAccount),
-            "index": mock_index,
-        }
-
-        self.mocks["account"].async_last_playback_state = AsyncMock()
-        self.mocks["account"].async_last_playback_state.return_value = {
-            "repeat_state": "context",
-            "shuffle_state": True,
-            "context": {
-                "uri": "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
-                "type": "playlist"
-            },
-            "item": {
-                "album": {
-                    "uri": "spotify:album:baz"
-                },
-                "uri": "spotify:track:bar"
-            }
-        }
-
-        self.mocks["account"].async_get_playlist_tracks = AsyncMock(
-            side_effect=SpotifyException(404, -1, "Resource not found")
-        )
-
-        self.call_data = {
-            "media_player": {
-                "entity_id": [
-                    "media_player.foo"
-                ]
-            },
-            "data": {
-                "position": 5
-            }
-        }
-
-        self.result = await async_rebuild_playback(
-            self.call_data,
-            self.mocks["account"],
-        )
-
-    def test_degrades_to_first_track(self):
-        self.assertEqual(self.result["data"]["offset"], 0)
-
-    def test_playlist_uri_kept(self):
-        self.assertEqual(
-            self.result["spotify_uri"],
-            "spotify:playlist:37i9dQZF1DX4sWSpwq3LiO",
-        )

--- a/test/spotify/account/test_async_play_media.py
+++ b/test/spotify/account/test_async_play_media.py
@@ -243,6 +243,68 @@ class TestMediaPlaybackWithExtras(IsolatedAsyncioTestCase):
             self.fail()
 
 
+class TestMediaPlaybackWithUriOffset(IsolatedAsyncioTestCase):
+    """A string offset is a track uri and must be passed to Spotify as a
+    uri-based offset, so playback starts at that track without resolving
+    its numeric position (see #582)."""
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_spotify: MagicMock,
+            mock_store: MagicMock,
+    ):
+
+        self.mocks = {
+            "internal": MagicMock(spec=DesktopSession),
+            "external": MagicMock(spec=PublicSession),
+            "hass": MagicMock(spec=HomeAssistant),
+        }
+        self.mocks["hass"].loop = MagicMock()
+
+        self.mock_spotify = mock_spotify
+
+        self.mocks["external"].token = {
+            "access_token": "12345",
+            "expires_at": 12345.61,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+            is_default=True
+        )
+
+        self.account.async_ensure_tokens_valid = AsyncMock()
+
+        self.account._datasets["profile"].expires_at = time() + 9999
+        self.account._datasets["profile"]._data = {"name": "Dummy"}
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock()
+
+        await self.account.async_play_media(
+            "foo",
+            "spotify:playlist:uri",
+            offset="spotify:track:bar",
+        )
+
+    def test_play_media_was_called(self):
+        try:
+            self.mocks["hass"].async_add_executor_job.assert_called_with(
+                self.account.apis["public"].start_playback,
+                "foo",
+                "spotify:playlist:uri",
+                None,
+                {"uri": "spotify:track:bar"},
+                None,
+            )
+        except AssertionError:
+            self.fail()
+
+
 class TestPlaybackError(IsolatedAsyncioTestCase):
 
     @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)


### PR DESCRIPTION
## Summary
When `transfer_playback` rebuilds playback from the last known state and the context is a **playlist or collection**, it fetched every track (50 per page, serially) just to find the current track's numeric index. On a large playlist (the reporter's was ~6000 tracks) that is ~120 sequential Spotify requests, which is why `transfer_playback` took **15-60 seconds** ([fondberg/spotcast#582](https://github.com/fondberg/spotcast/issues/582)).

## Change
Spotify's `start_playback` accepts a **uri-based offset**, so we pass the current track's uri directly and let Spotify resolve the position:
- `account.async_play_media` now accepts a `str` offset (a track uri) in addition to an `int` position, mapping it to `offset={"uri": ...}`.
- `async_rebuild_playback` sets the offset to `current_item["uri"]` for playlist/collection contexts instead of paginating.

This turns ~120 requests into **one**, and as a bonus it also works for editorial/algorithmic playlists that 404 on the Web API, so the old 404 degradation branch (and its whole-playlist fetch helper) is removed.

## Validation
Verified against a live account: starting an editorial playlist context with `offset={"uri": <track>}` played that exact track (HTTP 204), and the previous per-track pagination is gone. Full suite green (613 tests), pylint 9.54 on the changed files.

Fixes fondberg/spotcast#582

🤖 Generated with [Claude Code](https://claude.com/claude-code)