### PR TITLE
Capitalize Chromecast and Spotify Connect in package description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "spotcast"
 version = "6.1.0"
-description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for chromecast as well as connect devices."
+description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for Chromecast as well as Spotify Connect devices."
 readme = "README.md"
 requires-python = ">=3.14.2"
 license = "LICENSE"


### PR DESCRIPTION
Normalizes the product-name capitalization in the `pyproject.toml` description ("chromecast" -> "Chromecast", "connect devices" -> "Spotify Connect devices") to match how these names are written everywhere else in the project. The GitHub repository description was corrected the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)