### PR TITLE
Wait and retry once on a 404 from start_playback (#572)

### DIFF
--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -909,17 +909,42 @@ class SpotifyAccount:
             uris = [context_uri]
             context_uri = None
 
+        start_args = (
+            self.apis["public"].start_playback,
+            device_id,
+            context_uri,
+            uris,
+            offset,
+            position,
+        )
+
         try:
-            await self.hass.async_add_executor_job(
-                self.apis["public"].start_playback,
-                device_id,
-                context_uri,
-                uris,
-                offset,
-                position,
-            )
+            await self.hass.async_add_executor_job(*start_args)
         except SpotifyException as exc:
-            raise PlaybackError(exc.msg) from exc
+            if exc.http_status != 404:
+                raise PlaybackError(exc.msg) from exc
+
+            # A Spotify Connect device that just came online (e.g. a
+            # librespot device) may not be registered yet when we issue
+            # the play command, so Spotify answers 404 "Device not found".
+            # Wait for it to appear and retry once before giving up,
+            # instead of surfacing an error the user cannot act on.
+            LOGGER.info(
+                "Device `%s` not found on first play attempt; waiting for "
+                "it to become available",
+                device_id,
+            )
+
+            try:
+                await self.async_wait_for_device(device_id)
+                await self.hass.async_add_executor_job(*start_args)
+            except TimeoutError as timeout_exc:
+                raise PlaybackError(
+                    f"Device `{device_id}` is not available on Spotify "
+                    "Connect."
+                ) from timeout_exc
+            except SpotifyException as retry_exc:
+                raise PlaybackError(retry_exc.msg) from retry_exc
 
     async def async_shuffle(
         self,

--- a/test/spotify/account/test_async_play_media.py
+++ b/test/spotify/account/test_async_play_media.py
@@ -305,6 +305,115 @@ class TestMediaPlaybackWithUriOffset(IsolatedAsyncioTestCase):
             self.fail()
 
 
+class TestDeviceNotReadyThenSucceeds(IsolatedAsyncioTestCase):
+    """A device that is not registered yet answers 404 on the first play
+    attempt. Spotcast waits for it and retries once, so playback starts
+    without surfacing an error (see #572)."""
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_spotify: MagicMock,
+            mock_store: MagicMock,
+    ):
+
+        self.mocks = {
+            "internal": MagicMock(spec=DesktopSession),
+            "external": MagicMock(spec=PublicSession),
+            "hass": MagicMock(spec=HomeAssistant),
+        }
+        self.mocks["hass"].loop = MagicMock()
+
+        self.mocks["external"].token = {
+            "access_token": "12345",
+            "expires_at": 12345.61,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+            is_default=True
+        )
+
+        self.account.async_ensure_tokens_valid = AsyncMock()
+        self.account.async_wait_for_device = AsyncMock()
+
+        self.account._datasets["profile"].expires_at = time() + 9999
+        self.account._datasets["profile"]._data = {"name": "Dummy"}
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            side_effect=[
+                SpotifyException(404, -1, "Device not found"),
+                None,
+            ]
+        )
+
+        await self.account.async_play_media("foo", "spotify:dummy:uri")
+
+    def test_waited_for_device(self):
+        try:
+            self.account.async_wait_for_device.assert_called_once_with("foo")
+        except AssertionError:
+            self.fail()
+
+    def test_play_retried(self):
+        self.assertEqual(
+            self.mocks["hass"].async_add_executor_job.call_count,
+            2,
+        )
+
+
+class TestDeviceNeverAvailable(IsolatedAsyncioTestCase):
+    """When the device never becomes available, waiting times out and a
+    clear PlaybackError is raised (see #572)."""
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def test_error_raised(
+            self,
+            mock_spotify: MagicMock,
+            mock_store: MagicMock,
+    ):
+
+        self.mocks = {
+            "internal": MagicMock(spec=DesktopSession),
+            "external": MagicMock(spec=PublicSession),
+            "hass": MagicMock(spec=HomeAssistant),
+        }
+        self.mocks["hass"].loop = MagicMock()
+
+        self.mocks["external"].token = {
+            "access_token": "12345",
+            "expires_at": 12345.61,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+            is_default=True
+        )
+
+        self.account.async_ensure_tokens_valid = AsyncMock()
+        self.account.async_wait_for_device = AsyncMock(
+            side_effect=TimeoutError()
+        )
+
+        self.account._datasets["profile"].expires_at = time() + 9999
+        self.account._datasets["profile"]._data = {"name": "Dummy"}
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock(
+            side_effect=SpotifyException(404, -1, "Device not found")
+        )
+
+        with self.assertRaises(PlaybackError):
+            await self.account.async_play_media("foo", "spotify:dummy:uri")
+
+
 class TestPlaybackError(IsolatedAsyncioTestCase):
 
     @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)


### PR DESCRIPTION
## Summary
Starting playback on a Spotify Connect device that just came online (for example a librespot-java device that is not connected yet) makes Spotify answer **404 "Device not found"** even though playback then starts. The 404 surfaced to the user as an error popup for an action that actually succeeded ([fondberg/spotcast#572](https://github.com/fondberg/spotcast/issues/572)).

## Change
On a 404 from `start_playback`, wait for the device to register with Spotify Connect (using the already-present but previously unused `async_wait_for_device`) and retry the play command once. If the device never becomes available, raise a clear `PlaybackError` ("Device ... is not available on Spotify Connect") instead of the raw Spotify error. Non-404 errors are unchanged.

## Validation
Verified against a live account that a play command to an unknown device returns exactly `404 "Device not found"` (the shape handled here). Unit tests cover 404-then-success (waits and retries) and device-never-available (clear error). Full suite green (615 tests).

Fixes fondberg/spotcast#572

🤖 Generated with [Claude Code](https://claude.com/claude-code)