### PR TITLE
Inline reauth translation strings and fix French step key

### DIFF
--- a/custom_components/spotcast/strings.json
+++ b/custom_components/spotcast/strings.json
@@ -13,7 +13,7 @@
                 "description": "Select the application credentials to use for this account."
             },
             "reauth_confirm": {
-                "title": "[%key:common::config_flow::title::reauth%]",
+                "title": "Re-authenticate Spotcast",
                 "description": "The Spotcast integration needs to re-authenticate your account."
             },
             "doc_confirm": {
@@ -32,7 +32,7 @@
             "already_configured": "This account is already configured in Home Assistant",
             "reauth_account_mismatch": "The account provided does not match the account being reauthenticated",
             "public_private_accounts_mismatch": "The profile from the OAuth credentials and the desktop credentials are for 2 different accounts. Make sure to provide information from the same account. If you are already logged in to Spotify on your browser, Home Assistant won't ask you to connect to a different account and will use the currently logged-in user.",
-            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+            "reauth_successful": "Re-authentication was successful"
         }
     },
     "options": {

--- a/custom_components/spotcast/translations/en.json
+++ b/custom_components/spotcast/translations/en.json
@@ -13,7 +13,7 @@
                 "description": "Select the application credentials to use for this account."
             },
             "reauth_confirm": {
-                "title": "[%key:common::config_flow::title::reauth%]",
+                "title": "Re-authenticate Spotcast",
                 "description": "The Spotcast integration needs to re-authenticate your account."
             },
             "doc_confirm": {
@@ -32,7 +32,7 @@
             "already_configured": "This account is already configured in Home Assistant",
             "reauth_account_mismatch": "The account provided does not match the account being reauthenticated",
             "public_private_accounts_mismatch": "The profile from the OAuth credentials and the desktop credentials are for 2 different accounts. Make sure to provide information from the same account. If you are already logged in to Spotify on your browser, Home Assistant won't ask you to connect to a different account and will use the currently logged-in user.",
-            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+            "reauth_successful": "Re-authentication was successful"
         }
     },
     "options": {

--- a/custom_components/spotcast/translations/fr.json
+++ b/custom_components/spotcast/translations/fr.json
@@ -12,8 +12,8 @@
                 "title": "Informations d'identification de l'application",
                 "description": "Sélectionnez les informations d'identification à utiliser pour ce compte."
             },
-            "reauth_config": {
-                "title": "[%key:common::config_flow::title::reauth%]",
+            "reauth_confirm": {
+                "title": "Ré-authentifier Spotcast",
                 "description": "L'intégration Spotcast a besoin de réauthentifier votre compte."
             },
             "doc_confirm": {
@@ -32,7 +32,7 @@
             "already_configured": "Ce compte est déjà configuré dans Home Assistant",
             "reauth_account_mismatch": "Le compte fourni ne concorde pas avec le compte Spotify étant réauthentifié",
             "public_private_accounts_mismatch": "Le profil lié aux informations d'identification OAuth et celui des informations d'identification du client de bureau sont pour des comptes différents. Faites attention à fournir les informations pour le même compte. Si vous êtes déjà connecté à Spotify dans votre navigateur web, Home Assistant ne vous demandera pas de vous connecter à un autre compte et utilisera le compte actuel.",
-            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+            "reauth_successful": "La ré-authentification a réussi"
         }
     },
     "options": {


### PR DESCRIPTION
## Summary
The reauth dialog title rendered as the literal `[%key:common::config_flow::title::reauth%]` instead of a proper label. The `[%key:...%]` reference syntax is only resolved by Home Assistant for **core** integrations during their translation build; a custom integration serves its `translations/*.json` verbatim, so the reference showed as raw text.

## Changes
- Inline the actual strings for the reauth `title` ("Re-authenticate Spotcast") and the `reauth_successful` abort ("Re-authentication was successful") in `strings.json`, `translations/en.json` and `translations/fr.json`.
- Fix `translations/fr.json`, where the reauth step was keyed `reauth_config` instead of `reauth_confirm`, so the reauth dialog previously had **no French translation** and fell back to the raw key.

No remaining `[%key:...%]` references in the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)