### PR TITLE
Key device identity on the name instead of the Spotify device id (#580, #586)

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -183,10 +183,22 @@ async def async_remove_config_entry_device(
     if account is None:
         return True
 
-    active_ids = {device["id"] for device in account.devices}
+    # Device registry entries are keyed on the stable identity key
+    # (name + account). Older entries may still be keyed on the raw
+    # Spotify device id, so accept both for the active check.
+    # local import avoids a circular import with the media_player package
+    from .media_player import (  # pylint: disable=import-outside-toplevel
+        SpotifyDevice,
+    )
+
+    active = {device["id"] for device in account.devices}
+    active |= {
+        SpotifyDevice.compute_identity_key(device["name"], account.id)
+        for device in account.devices
+    }
 
     return not any(
-        identifier in active_ids
+        identifier in active
         for domain, identifier in device_entry.identifiers
         if domain == DOMAIN
     )

--- a/custom_components/spotcast/media_player/device_manager.py
+++ b/custom_components/spotcast/media_player/device_manager.py
@@ -10,7 +10,9 @@ from time import time
 
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.device_registry import async_get as async_get_dr
+from homeassistant.helpers.entity_registry import async_get as async_get_er
 
+from custom_components.spotcast.const import DOMAIN
 from custom_components.spotcast.media_player import (
     SpotifyDevice,
 )
@@ -45,7 +47,6 @@ class DeviceManager:
 
     DELETE_ON_UNAVAILABLE = (
         "Web Player",
-        "Echo Speaker",
     )
 
     STALE_DEVICE_TIMEOUT = 7 * 24 * 3600
@@ -77,35 +78,18 @@ class DeviceManager:
             self.supervisor._is_healthy = False
             self.supervisor.log_message(exc)
 
-    async def async_manage_devices(self, current_devices: dict):
-        current_devices = {x["id"]: x for x in current_devices}
-        remove = []
+    def _key_current_devices(self, current_devices: list) -> dict:
+        """Keys the devices reported by Spotify by their stable identity
+        key (name + account) rather than the ephemeral Spotify device id,
+        after cleaning the type and dropping ignored devices.
 
-        # remove no longer available devices first
-        for id, device in self.tracked_devices.items():
-            if id not in current_devices:
-                LOGGER.info(
-                    "Marking device `%s` unavailable for account `%s`",
-                    device.name,
-                    self._account.name
-                )
-                remove.append(id)
-                entity = self.tracked_devices[id]
-                entity.is_unavailable = True
+        Two devices sharing a name would collide on the identity key, so
+        the second one keeps the Spotify device id as a disambiguator and
+        falls back to the legacy per-id behaviour.
+        """
+        current: dict[str, dict] = {}
 
-        for id in remove:
-
-            device = self.tracked_devices.pop(id)
-
-            if device.device_data["type"] in self.DELETE_ON_UNAVAILABLE:
-                await device.async_remove(force_remove=True)
-                self.remove_device(device.device_info["identifiers"])
-            else:
-                self.unavailable_devices[id] = device
-                self.unavailable_since[id] = time()
-
-        for id, device in current_devices.items():
-
+        for device in current_devices:
             device["type"] = self.clean_device_type(device)
 
             if device["type"] in self.IGNORE_DEVICE_TYPES:
@@ -116,31 +100,83 @@ class DeviceManager:
                 )
                 continue
 
-            if (
-                id not in self.tracked_devices
-                and id in self.unavailable_devices
-            ):
+            key = SpotifyDevice.compute_identity_key(
+                device["name"],
+                self._account.id,
+            )
+
+            if key in current and current[key]["id"] != device["id"]:
+                LOGGER.warning(
+                    "Two Spotify Connect devices named `%s` for account "
+                    "`%s`; keeping them as separate entities",
+                    device["name"],
+                    self._account.name,
+                )
+                key = f"{key}_{device['id']}"
+
+            current[key] = device
+
+        return current
+
+    async def async_manage_devices(self, current_devices: dict):
+        current = self._key_current_devices(current_devices)
+        remove = []
+
+        # mark no longer available devices first
+        for key, device in self.tracked_devices.items():
+            if key not in current:
+                LOGGER.info(
+                    "Marking device `%s` unavailable for account `%s`",
+                    device.name,
+                    self._account.name
+                )
+                remove.append(key)
+                device.is_unavailable = True
+
+        for key in remove:
+
+            device = self.tracked_devices.pop(key)
+
+            if device.device_data["type"] in self.DELETE_ON_UNAVAILABLE:
+                await device.async_remove(force_remove=True)
+                self.remove_device(device.device_info["identifiers"])
+            else:
+                self.unavailable_devices[key] = device
+                self.unavailable_since[key] = time()
+
+        for key, device in current.items():
+
+            if key in self.tracked_devices:
+                continue
+
+            if key in self.unavailable_devices:
                 LOGGER.info(
                     "Device `%s` has became available again for account `%s`",
                     device["name"],
                     self._account.name,
                 )
-                self.tracked_devices[id] = self.unavailable_devices.pop(id)
-                self.unavailable_since.pop(id, None)
-                self.tracked_devices[id].is_unavailable = False
+                # rebind the device data so the (possibly new) Spotify
+                # device id is picked up without creating a new entity.
+                entity = self.unavailable_devices.pop(key)
+                self.unavailable_since.pop(key, None)
+                entity.device_data = device
+                entity.is_unavailable = False
+                self.tracked_devices[key] = entity
+                continue
 
-            elif (
-                id not in self.tracked_devices
-                and id not in self.unavailable_devices
-            ):
-                LOGGER.info(
-                    "Adding New Device `%s` for account `%s`",
-                    device["name"],
-                    self._account.name,
-                )
-                new_device = SpotifyDevice(self._account, device)
-                self.tracked_devices[id] = new_device
-                self.async_add_entities([new_device])
+            LOGGER.info(
+                "Adding New Device `%s` for account `%s`",
+                device["name"],
+                self._account.name,
+            )
+            self._migrate_legacy_entity(key, device)
+            new_device = SpotifyDevice(
+                self._account,
+                device,
+                identity_key=key,
+            )
+            self.tracked_devices[key] = new_device
+            self.async_add_entities([new_device])
 
         playback_state = await self._account.async_playback_state()
         playing_id = None
@@ -148,9 +184,9 @@ class DeviceManager:
         if "device" in playback_state:
             playing_id = playback_state["device"]["id"]
 
-        for id, device in self.tracked_devices.items():
+        for key, device in self.tracked_devices.items():
             LOGGER.debug("Updating device info for `%s`", device.name)
-            device.device_data = current_devices[id]
+            device.device_data = current[key]
 
             if device.id == playing_id:
                 LOGGER.debug("Feeding playback state to `%s`", device.name)
@@ -159,6 +195,69 @@ class DeviceManager:
                 device.playback_state = {}
 
         await self.async_purge_stale_devices()
+
+    def _migrate_legacy_entity(self, key: str, device: dict):
+        """Migrates an entity created by an older version, keyed on the
+        ephemeral Spotify device id, onto the stable identity key. This
+        keeps a user's existing entity and device (and any automation
+        referencing them) instead of creating a duplicate on upgrade.
+
+        Only devices that are currently online with the same Spotify id
+        as before the upgrade can be reconciled here. Devices whose id
+        changed while Home Assistant was down create a fresh entity and
+        the old one is cleaned up by the stale-device purge.
+        """
+        entity_registry = async_get_er(self._account.hass)
+        new_unique_id = f"{key}_spotcast_device"
+
+        if entity_registry.async_get_entity_id(
+            "media_player", DOMAIN, new_unique_id
+        ):
+            return
+
+        old_unique_id = f"{device['id']}_{self._account.id}_spotcast_device"
+        entity_id = entity_registry.async_get_entity_id(
+            "media_player", DOMAIN, old_unique_id
+        )
+
+        if entity_id is None:
+            return
+
+        try:
+            entity_registry.async_update_entity(
+                entity_id,
+                new_unique_id=new_unique_id,
+            )
+        except ValueError:
+            LOGGER.debug(
+                "Could not migrate unique id for device `%s`",
+                device["name"],
+            )
+            return
+
+        LOGGER.info(
+            "Migrated device `%s` to stable identity `%s`",
+            device["name"],
+            key,
+        )
+
+        # move the device registry entry onto the stable identifier while
+        # keeping the same Home Assistant device id, so automations that
+        # target the device keep working (see #586).
+        device_registry = async_get_dr(self._account.hass)
+        old_identifiers = {(DOMAIN, device["id"])}
+        new_identifiers = {(DOMAIN, key)}
+
+        if device_registry.async_get_device(new_identifiers) is not None:
+            return
+
+        device_entry = device_registry.async_get_device(old_identifiers)
+
+        if device_entry is not None:
+            device_registry.async_update_device(
+                device_entry.id,
+                new_identifiers=new_identifiers,
+            )
 
     async def async_purge_stale_devices(self):
         """Removes devices that have been unavailable for longer than

--- a/custom_components/spotcast/media_player/spotify_player.py
+++ b/custom_components/spotcast/media_player/spotify_player.py
@@ -40,7 +40,12 @@ class SpotifyDevice(MediaPlayer, MediaPlayerEntity):
 
     INTEGRATION = DOMAIN
 
-    def __init__(self, account: SpotifyAccount, device_data: dict):
+    def __init__(
+        self,
+        account: SpotifyAccount,
+        device_data: dict,
+        identity_key: str | None = None,
+    ):
         """Initialize the spotify device
 
         Args:
@@ -48,25 +53,38 @@ class SpotifyDevice(MediaPlayer, MediaPlayerEntity):
                 to.
             - device_data(dict): the information related to device
                 provided by the Spotify API
+            - identity_key(str, optional): the stable key to base the
+                unique id, entity id and device registry entry on. When
+                omitted it is derived from the device name and account,
+                which is what keeps the entity stable across the Spotify
+                Connect device id changing between sessions (see #580,
+                #586). The DeviceManager passes an explicit key when a
+                name collision requires disambiguation.
         """
         self.device_data: dict = device_data
         self._attr_extra_state_attributes = self.device_data
         self._account: SpotifyAccount = account
+        self._identity_key = identity_key or self.compute_identity_key(
+            device_data["name"], account.id
+        )
+        self._attr_unique_id = f"{self._identity_key}_spotcast_device"
         self.entity_id = self._define_entity_id()
         self.is_unavailable = False
         self.playback_state: dict = {}
 
         self.device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.id)},
+            identifiers={(DOMAIN, self._identity_key)},
             manufacturer="Spotify AB",
             model=f"Spotify Connect {self.device_data['type']}",
             name=self.name,
         )
 
-    @property
-    def unique_id(self) -> str:
-        """The unique identifier for Home Assistant"""
-        return f"{self.id}_{self._account.id}_spotcast_device"
+    @staticmethod
+    def compute_identity_key(name: str, account_id: str) -> str:
+        """The stable identity key for a device. Based on the device
+        name (which is stable) rather than the Spotify Connect device id
+        (which changes between sessions for some devices)."""
+        return f"{slugify(name)}_{account_id}"
 
     @property
     def id(self) -> str:
@@ -112,8 +130,6 @@ class SpotifyDevice(MediaPlayer, MediaPlayerEntity):
         return STATE_ON if is_active else STATE_OFF
 
     def _define_entity_id(self):
-        """Define the entity ID based on the account profile"""
+        """Define the entity ID from the stable identity key"""
 
-        name = slugify(self.device_data["name"])
-
-        return f"media_player.{name}_{self._account.id}_spotcast"
+        return f"media_player.{self._identity_key}_spotcast"

--- a/test/media_player/device_manager/test_async_update.py
+++ b/test/media_player/device_manager/test_async_update.py
@@ -11,6 +11,20 @@ from custom_components.spotcast.media_player.device_manager import (
     RetrySupervisor,
 )
 
+from test.media_player.device_manager import TEST_MODULE
+
+# identity key for a device named "dummy device" on account "dummy"
+KEY = "dummy_device_dummy"
+WEB_KEY = "web_player_dummy_dummy"
+
+
+def _registry_without_legacy():
+    """A registry mock where no legacy entity exists, so the lazy
+    migration is a no-op."""
+    registry = MagicMock()
+    registry.async_get_entity_id = MagicMock(return_value=None)
+    return registry
+
 
 class TestSupervisorNotReady(IsolatedAsyncioTestCase):
 
@@ -79,9 +93,14 @@ class TestFailedToRetrieveDevices(IsolatedAsyncioTestCase):
 
 class TestNewDevices(IsolatedAsyncioTestCase):
 
-    async def asyncSetUp(self):
+    @patch(f"{TEST_MODULE}.async_get_er")
+    async def asyncSetUp(self, mock_er: MagicMock):
+
+        mock_er.return_value = _registry_without_legacy()
 
         self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
         self.mock_callack = MagicMock(spec=AddEntitiesCallback)
 
         self.mock_account.async_devices = AsyncMock(
@@ -93,6 +112,7 @@ class TestNewDevices(IsolatedAsyncioTestCase):
                 }
             ]
         )
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
 
         self.device_manager = DeviceManager(
             self.mock_account,
@@ -103,7 +123,7 @@ class TestNewDevices(IsolatedAsyncioTestCase):
 
     async def test_device_added_to_tracked(self):
         self.assertEqual(len(self.device_manager.tracked_devices), 1)
-        self.assertIn("1234", self.device_manager.tracked_devices)
+        self.assertIn(KEY, self.device_manager.tracked_devices)
 
     async def test_entity_was_added(self):
         try:
@@ -114,9 +134,14 @@ class TestNewDevices(IsolatedAsyncioTestCase):
 
 class TestNewWebPlayer(IsolatedAsyncioTestCase):
 
-    async def asyncSetUp(self):
+    @patch(f"{TEST_MODULE}.async_get_er")
+    async def asyncSetUp(self, mock_er: MagicMock):
+
+        mock_er.return_value = _registry_without_legacy()
 
         self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
         self.mock_callack = MagicMock(spec=AddEntitiesCallback)
 
         self.mock_account.async_devices = AsyncMock(
@@ -128,6 +153,7 @@ class TestNewWebPlayer(IsolatedAsyncioTestCase):
                 }
             ]
         )
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
 
         self.device_manager = DeviceManager(
             self.mock_account,
@@ -138,11 +164,11 @@ class TestNewWebPlayer(IsolatedAsyncioTestCase):
 
     def test_device_added_to_tracked(self):
         self.assertEqual(len(self.device_manager.tracked_devices), 1)
-        self.assertIn("1234", self.device_manager.tracked_devices)
+        self.assertIn(WEB_KEY, self.device_manager.tracked_devices)
 
     def test_device_class_changed_to_web_player(self):
         self.assertEqual(
-            self.device_manager.tracked_devices["1234"].device_data["type"],
+            self.device_manager.tracked_devices[WEB_KEY].device_data["type"],
             "Web Player",
         )
 
@@ -158,6 +184,8 @@ class TestIgnoredDevice(IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
 
         self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
         self.mock_callack = MagicMock(spec=AddEntitiesCallback)
 
         self.mock_account.async_devices = AsyncMock(
@@ -169,6 +197,7 @@ class TestIgnoredDevice(IsolatedAsyncioTestCase):
                 }
             ]
         )
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
 
         self.device_manager = DeviceManager(
             self.mock_account,
@@ -186,6 +215,8 @@ class TestAlreadyTrackedDevice(IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
 
         self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
         self.mock_callack = MagicMock(spec=AddEntitiesCallback)
 
         self.mock_account.async_devices = AsyncMock(
@@ -197,6 +228,7 @@ class TestAlreadyTrackedDevice(IsolatedAsyncioTestCase):
                 }
             ]
         )
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
 
         self.device_manager = DeviceManager(
             self.mock_account,
@@ -204,7 +236,7 @@ class TestAlreadyTrackedDevice(IsolatedAsyncioTestCase):
         )
 
         self.device_manager.tracked_devices = {
-            "1234": MagicMock(spec=SpotifyDevice)
+            KEY: MagicMock(spec=SpotifyDevice)
         }
 
         await self.device_manager.async_update()
@@ -224,6 +256,8 @@ class TestUnavailableDevice(IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
 
         self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
         self.mock_callack = MagicMock(spec=AddEntitiesCallback)
 
         self.mock_account.async_devices = AsyncMock(
@@ -235,6 +269,7 @@ class TestUnavailableDevice(IsolatedAsyncioTestCase):
                 }
             ]
         )
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
 
         self.device_manager = DeviceManager(
             self.mock_account,
@@ -242,23 +277,81 @@ class TestUnavailableDevice(IsolatedAsyncioTestCase):
         )
 
         self.device_manager.unavailable_devices = {
-            "1234": MagicMock(spec=SpotifyDevice)
+            KEY: MagicMock(spec=SpotifyDevice)
         }
 
-        self.device_manager.unavailable_devices["1234"].is_unavailable = True
+        self.device_manager.unavailable_devices[KEY].is_unavailable = True
 
         await self.device_manager.async_update()
 
     def test_device_added_to_tracked(self):
-        self.assertIn("1234", self.device_manager.tracked_devices)
+        self.assertIn(KEY, self.device_manager.tracked_devices)
 
     def test_device_was_set_to_available(self):
         self.assertFalse(
-            self.device_manager.tracked_devices["1234"].is_unavailable
+            self.device_manager.tracked_devices[KEY].is_unavailable
         )
 
     def test_device_removed_from_unavailable(self):
-        self.assertNotIn("1234", self.device_manager.unavailable_devices)
+        self.assertNotIn(KEY, self.device_manager.unavailable_devices)
+
+
+class TestReconnectWithNewId(IsolatedAsyncioTestCase):
+    """A device that reappears with a NEW Spotify device id but the same
+    name reuses the existing entity (keyed on the name) and rebinds the
+    new id, instead of creating a duplicate (see #580, #586)."""
+
+    async def asyncSetUp(self):
+
+        self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
+        self.mock_callack = MagicMock(spec=AddEntitiesCallback)
+
+        self.mock_account.async_devices = AsyncMock(
+            return_value=[
+                {
+                    "id": "new-id-9999",
+                    "name": "dummy device",
+                    "type": "Computer",
+                }
+            ]
+        )
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
+
+        self.device_manager = DeviceManager(
+            self.mock_account,
+            self.mock_callack,
+        )
+
+        self.existing = MagicMock(spec=SpotifyDevice)
+        self.existing.is_unavailable = True
+        self.device_manager.unavailable_devices = {KEY: self.existing}
+        self.device_manager.unavailable_since = {KEY: 0.0}
+
+        await self.device_manager.async_update()
+
+    def test_no_new_entity_created(self):
+        try:
+            self.mock_callack.assert_not_called()
+        except AssertionError:
+            self.fail()
+
+    def test_existing_entity_reused(self):
+        self.assertIs(self.device_manager.tracked_devices[KEY], self.existing)
+
+    def test_new_device_id_rebound(self):
+        self.assertEqual(
+            self.existing.device_data,
+            {
+                "id": "new-id-9999",
+                "name": "dummy device",
+                "type": "Computer",
+            },
+        )
+
+    def test_marked_available(self):
+        self.assertFalse(self.existing.is_unavailable)
 
 
 class TestCurrentlyPlayingDevice(IsolatedAsyncioTestCase):
@@ -266,6 +359,8 @@ class TestCurrentlyPlayingDevice(IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
 
         self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
         self.mock_callack = MagicMock(spec=AddEntitiesCallback)
 
         self.mock_account.async_devices = AsyncMock(
@@ -293,14 +388,14 @@ class TestCurrentlyPlayingDevice(IsolatedAsyncioTestCase):
         )
 
         self.device_manager.tracked_devices = {
-            "1234": MagicMock(spec=SpotifyDevice)
+            KEY: MagicMock(spec=SpotifyDevice)
         }
-        self.device_manager.tracked_devices["1234"].id = "1234"
+        self.device_manager.tracked_devices[KEY].id = "1234"
 
         await self.device_manager.async_update()
 
     async def test_device_playback_updated(self):
-        self.device_manager.tracked_devices["1234"].playback_state = {
+        self.device_manager.tracked_devices[KEY].playback_state = {
             "device": {
                 "id": "1234",
             },
@@ -315,6 +410,8 @@ class TestRemovedDevice(IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
 
         self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
         self.mock_callack = MagicMock(spec=AddEntitiesCallback)
         self.mock_device = MagicMock(spec=SpotifyDevice)
         self.mock_device.device_data = {
@@ -331,7 +428,7 @@ class TestRemovedDevice(IsolatedAsyncioTestCase):
         )
 
         self.device_manager.tracked_devices = {
-            "1234": self.mock_device
+            KEY: self.mock_device
         }
 
         await self.device_manager.async_update()
@@ -340,7 +437,47 @@ class TestRemovedDevice(IsolatedAsyncioTestCase):
         self.assertEqual(len(self.device_manager.tracked_devices), 0)
 
     def test_device_added_to_unavailable_devices(self):
-        self.assertIn("1234", self.device_manager.unavailable_devices)
+        self.assertIn(KEY, self.device_manager.unavailable_devices)
+
+
+class TestUnavailableEchoNotDeleted(IsolatedAsyncioTestCase):
+    """Echo speakers get a new id after inactivity. They must NOT be
+    deleted immediately on unavailability (which broke automations), but
+    kept and reconciled/purged like any other device (see #586)."""
+
+    async def asyncSetUp(self):
+
+        self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
+        self.mock_callack = MagicMock(spec=AddEntitiesCallback)
+        self.mock_device = MagicMock(spec=SpotifyDevice)
+        self.mock_device.device_data = {
+            "type": "Echo Speaker"
+        }
+
+        self.mock_account.async_devices = AsyncMock(return_value=[])
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
+
+        self.device_manager = DeviceManager(
+            self.mock_account,
+            self.mock_callack,
+        )
+
+        self.device_manager.tracked_devices = {
+            "echo_dummy": self.mock_device
+        }
+
+        await self.device_manager.async_update()
+
+    def test_not_removed_from_hass(self):
+        try:
+            self.mock_device.async_remove.assert_not_called()
+        except AssertionError:
+            self.fail()
+
+    def test_moved_to_unavailable(self):
+        self.assertIn("echo_dummy", self.device_manager.unavailable_devices)
 
 
 class TestRemovedWebPlayer(IsolatedAsyncioTestCase):
@@ -355,6 +492,8 @@ class TestRemovedWebPlayer(IsolatedAsyncioTestCase):
             "remove": mock_remove,
         }
 
+        self.mocks["account"].id = "dummy"
+        self.mocks["account"].hass = MagicMock()
         self.mocks["account"].async_devices = AsyncMock(return_value=[])
         self.mocks["account"].async_playback_state = AsyncMock()
         self.mocks["account"].async_playback_state.return_value = {}
@@ -365,15 +504,15 @@ class TestRemovedWebPlayer(IsolatedAsyncioTestCase):
         )
 
         self.device_manager.tracked_devices = {
-            "1234": self.mocks["device"]
+            WEB_KEY: self.mocks["device"]
         }
 
-        self.device_manager.tracked_devices["1234"].device_data = {
+        self.device_manager.tracked_devices[WEB_KEY].device_data = {
             "type": "Web Player"
         }
 
-        self.device_manager.tracked_devices["1234"].device_info = {
-            "identifiers": {("spotcast", "1234")}
+        self.device_manager.tracked_devices[WEB_KEY].device_info = {
+            "identifiers": {("spotcast", WEB_KEY)}
         }
 
         await self.device_manager.async_update()
@@ -390,5 +529,73 @@ class TestRemovedWebPlayer(IsolatedAsyncioTestCase):
     def test_remove_device_called(self):
         try:
             self.mocks["remove"].assert_called()
+        except AssertionError:
+            self.fail()
+
+
+class TestLegacyEntityMigration(IsolatedAsyncioTestCase):
+    """On upgrade, an entity created by an older version (keyed on the
+    Spotify device id) is renamed to the stable name-based unique id and
+    its device registry entry is moved, instead of creating a duplicate."""
+
+    @patch(f"{TEST_MODULE}.async_get_dr")
+    @patch(f"{TEST_MODULE}.async_get_er")
+    async def asyncSetUp(self, mock_er: MagicMock, mock_dr: MagicMock):
+
+        self.entity_registry = MagicMock()
+        # new unique id absent, legacy id-based unique id present
+        self.entity_registry.async_get_entity_id = MagicMock(
+            side_effect=[None, "media_player.dummy_device_dummy_spotcast"]
+        )
+        self.entity_registry.async_update_entity = MagicMock()
+        mock_er.return_value = self.entity_registry
+
+        self.device_entry = MagicMock()
+        self.device_entry.id = "ha-device-id"
+        self.device_registry = MagicMock()
+        self.device_registry.async_get_device = MagicMock(
+            side_effect=[None, self.device_entry]
+        )
+        self.device_registry.async_update_device = MagicMock()
+        mock_dr.return_value = self.device_registry
+
+        self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+        self.mock_account.hass = MagicMock()
+        self.mock_callack = MagicMock(spec=AddEntitiesCallback)
+
+        self.mock_account.async_devices = AsyncMock(
+            return_value=[
+                {
+                    "id": "1234",
+                    "name": "dummy device",
+                    "type": "Computer",
+                }
+            ]
+        )
+        self.mock_account.async_playback_state = AsyncMock(return_value={})
+
+        self.device_manager = DeviceManager(
+            self.mock_account,
+            self.mock_callack,
+        )
+
+        await self.device_manager.async_update()
+
+    def test_unique_id_migrated(self):
+        try:
+            self.entity_registry.async_update_entity.assert_called_once_with(
+                "media_player.dummy_device_dummy_spotcast",
+                new_unique_id="dummy_device_dummy_spotcast_device",
+            )
+        except AssertionError:
+            self.fail()
+
+    def test_device_registry_identifier_moved(self):
+        try:
+            self.device_registry.async_update_device.assert_called_once_with(
+                "ha-device-id",
+                new_identifiers={("spotcast", KEY)},
+            )
         except AssertionError:
             self.fail()

--- a/test/media_player/spotify_device/test_unique_id.py
+++ b/test/media_player/spotify_device/test_unique_id.py
@@ -1,7 +1,7 @@
 """Module to test the unique_id property"""
 
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from custom_components.spotcast.media_player.spotify_player import (
     SpotifyAccount,
@@ -26,4 +26,68 @@ class TestValue(TestCase):
         )
 
     def test_unique_id_value(self):
-        self.assertEqual(self.device.unique_id, "12345_dummy_spotcast_device")
+        self.assertEqual(
+            self.device.unique_id,
+            "dummy_device_dummy_spotcast_device",
+        )
+
+
+class TestStableAcrossDeviceIdChange(TestCase):
+    """The unique id must be based on the device name, not the Spotify
+    device id, so it stays stable when Spotify assigns the device a new
+    id between sessions (see #580, #586)."""
+
+    def setUp(self):
+
+        self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+
+        self.device = SpotifyDevice(
+            self.mock_account,
+            {
+                "id": "12345",
+                "name": "dummy_device",
+                "type": "dummy",
+            }
+        )
+
+    def test_unique_id_unchanged_when_device_id_changes(self):
+        before = self.device.unique_id
+        self.device.device_data = {
+            "id": "a-brand-new-id",
+            "name": "dummy_device",
+            "type": "dummy",
+        }
+        self.assertEqual(self.device.unique_id, before)
+
+
+class TestExplicitIdentityKey(TestCase):
+    """The DeviceManager can pass an explicit identity key to
+    disambiguate devices that share a name."""
+
+    def setUp(self):
+
+        self.mock_account = MagicMock(spec=SpotifyAccount)
+        self.mock_account.id = "dummy"
+
+        self.device = SpotifyDevice(
+            self.mock_account,
+            {
+                "id": "12345",
+                "name": "dummy_device",
+                "type": "dummy",
+            },
+            identity_key="dummy_device_dummy_12345",
+        )
+
+    def test_unique_id_uses_explicit_key(self):
+        self.assertEqual(
+            self.device.unique_id,
+            "dummy_device_dummy_12345_spotcast_device",
+        )
+
+    def test_entity_id_uses_explicit_key(self):
+        self.assertEqual(
+            self.device.entity_id,
+            "media_player.dummy_device_dummy_12345_spotcast",
+        )

--- a/test/test_async_remove_config_entry_device.py
+++ b/test/test_async_remove_config_entry_device.py
@@ -22,7 +22,8 @@ def build_mocks(active_ids: list[str], identifiers: set) -> dict:
         "device": MagicMock(spec=DeviceEntry),
     }
     mocks["entry"].entry_id = "12345"
-    mocks["account"].devices = [{"id": x} for x in active_ids]
+    mocks["account"].id = "acct"
+    mocks["account"].devices = [{"id": x, "name": x} for x in active_ids]
     mocks["device"].identifiers = identifiers
     mocks["hass"].data = {
         DOMAIN: {"12345": {"account": mocks["account"]}}
@@ -44,6 +45,19 @@ class TestActiveDeviceRemoval(IsolatedAsyncioTestCase):
 
     async def test_active_device_cannot_be_removed(self):
         mocks = build_mocks(["foo"], {(DOMAIN, "foo")})
+        result = await async_remove_config_entry_device(
+            mocks["hass"], mocks["entry"], mocks["device"],
+        )
+        self.assertFalse(result)
+
+
+class TestActiveDeviceByIdentityKey(IsolatedAsyncioTestCase):
+
+    async def test_active_device_by_key_cannot_be_removed(self):
+        # device registry entries are keyed on the stable identity key
+        # (name + account), so an active device must be protected when
+        # matched by that key too
+        mocks = build_mocks(["foo"], {(DOMAIN, "foo_acct")})
         result = await async_remove_config_entry_device(
             mocks["hass"], mocks["entry"], mocks["device"],
         )


### PR DESCRIPTION
## Summary
The media player `unique_id` and device-registry identifier were derived from the **Spotify Connect device id**, which some devices (iPhones, Alexa multiroom speakers) change between sessions. Home Assistant therefore created a brand-new entity each time the id changed, leaving orphaned `_2`..`_6` duplicates ([fondberg/spotcast#580](https://github.com/fondberg/spotcast/issues/580)) and breaking automations that referenced the device or its HA device id ([fondberg/spotcast#586](https://github.com/fondberg/spotcast/issues/586)).

Investigation confirmed the internal connect-state device id is the *same* ephemeral value as the Web API id, so a stable name-based key is the correct fix.

## Change
- Identity is now a stable key: `slugify(name)_{account.id}`, captured immutably at construction and used for `unique_id`, `entity_id` and the device-registry identifier. The live Spotify id stays available (mutable) for API calls.
- **Reconciliation:** when a device reappears with a new Spotify id but the same name, its data is rebound onto the existing entity instead of creating a new one.
- **Name collisions:** two devices sharing a name fall back to a per-id key (logged).
- Echo speakers are no longer deleted the moment they go unavailable (that made #586 worse); they are reconciled/purged like any other device. Web Player devices are still deleted on unavailability.
- **Lazy upgrade migration:** a device seen online with the same Spotify id as before the upgrade has its old id-based `unique_id` renamed to the stable key and its device-registry entry moved, preserving the HA device id so automations keep working. Devices whose id changed while HA was down create a fresh entity and the old one is cleaned up by the existing 7-day stale-device purge.
- `async_remove_config_entry_device` now matches the active-device check on both the identity key and the raw id.

## Tests
Full suite green (625 tests), pylint 9.75. New coverage: unique id stable across a device-id change, reconnect-with-new-id reuses the entity, Echo not deleted on unavailability, and the legacy unique-id/device-registry migration.

Fixes fondberg/spotcast#580
Fixes fondberg/spotcast#586

🤖 Generated with [Claude Code](https://claude.com/claude-code)