### PR TITLE
Add a paste-URL desktop authorization option (relay optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Spotcast is a Home Assistant custom integration that starts Spotify playback on 
 > Spotcast requires a **Spotify Premium** account to work.
 
 > [!WARNING]
-> Some Spotcast features need permissions that Spotify does not grant to regular third-party applications. To obtain them, Spotcast authenticates one session under the identity of the official Spotify desktop application (this is why the setup involves a desktop token and a relay server). This method is not officially supported by Spotify and may stop working without notice if Spotify changes its authentication systems. We do our best to adapt quickly when that happens, but temporary breakage is always possible.
+> Some Spotcast features need permissions that Spotify does not grant to regular third-party applications. To obtain them, Spotcast authenticates one session under the identity of the official Spotify desktop application (this is the desktop authorization step during setup). This method is not officially supported by Spotify and may stop working without notice if Spotify changes its authentication systems. We do our best to adapt quickly when that happens, but temporary breakage is always possible.
 
 > [!NOTE]
 > This repository is the continuation of the original [fondberg/spotcast](https://github.com/fondberg/spotcast) project, created by Niklas Fondberg ([@fondberg](https://github.com/fondberg)) and maintained through v5 and the v6 rewrite by Felix Cusson ([@fcusson](https://github.com/fcusson)). Development now happens here, starting with the v6 release.
@@ -147,7 +147,7 @@ Spotcast provides multiple WebSocket API endpoints, used for example by companio
 
 The v6 rewrite changed both the configuration flow and the action names:
 
-- Configuration no longer uses `sp_dc`/`sp_key` cookies in YAML. Accounts are set up through the UI with OAuth and a one-time desktop token relay. Follow the [configuration guide](./docs/config/spotcast_configuration.md).
+- Configuration no longer uses `sp_dc`/`sp_key` cookies in YAML. Accounts are set up through the UI with OAuth and a one-time desktop authorization. Follow the [configuration guide](./docs/config/spotcast_configuration.md).
 - The `spotcast.start` service was replaced by a set of dedicated actions. The closest equivalent to `spotcast.start` is [`spotcast.play_media`](./docs/services/play_media.md), with most of its former options now under the `data` section.
 - `spotcast.play_category` was removed, following the deprecation of the corresponding Spotify Web API endpoints.
 

--- a/custom_components/spotcast/config_flow_classes/config_flow_handler.py
+++ b/custom_components/spotcast/config_flow_classes/config_flow_handler.py
@@ -6,10 +6,12 @@ Classes:
 
 from logging import getLogger
 from typing import Any, TYPE_CHECKING
+from urllib.parse import urlsplit, parse_qs
 
 from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import BooleanSelector
+from homeassistant.helpers.config_entry_oauth2_flow import _decode_jwt
 from homeassistant.components.spotify.config_flow import SpotifyFlowHandler
 from homeassistant.config_entries import (
     ConfigFlowResult,
@@ -51,6 +53,24 @@ _SETUP_GUIDE_URL = (
     "https://github.com/Mincka/spotcast/blob/main/docs/config/"
     "spotcast_configuration.md"
 )
+
+# The redirect uri registered for the Spotify desktop client. The manual
+# authentication path asks the user to paste the browser URL that lands
+# on it after authorizing.
+_DESKTOP_REDIRECT_URI = "http://127.0.0.1:8080/login"
+
+
+class ManualAuthError(Exception):
+    """Raised when a pasted desktop-authentication URL cannot be used.
+
+    Attributes:
+        error_key(str): the translation key of the error to show on the
+            form.
+    """
+
+    def __init__(self, error_key: str):
+        super().__init__(error_key)
+        self.error_key = error_key
 
 
 class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
@@ -96,6 +116,12 @@ class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
         }
     )
 
+    MANUAL_AUTH_SCHEMA = vol.Schema(
+        {
+            vol.Required("pasted_url"): cv.string,
+        }
+    )
+
     def __init__(self):
         """Constructor of the Spotcast Config Flow."""
         super().__init__()
@@ -104,6 +130,7 @@ class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
             "version": self.version,
         }
         self._pcke_impl = None
+        self._manual_auth_url = None
 
     @property
     def version(self) -> str:
@@ -165,6 +192,112 @@ class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
         """Passes the external steps result to oauth create entry."""
         return await self.async_oauth_create_entry(user_input)
 
+    async def async_step_desktop_auth(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Lets the user choose how to provide the desktop token."""
+        return self.async_show_menu(
+            step_id="desktop_auth",
+            menu_options=["desktop_api_manual", "desktop_api_auto"],
+        )
+
+    async def async_step_desktop_api_auto(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Automatic path: a local relay server redirects the browser
+        back to Home Assistant to complete the authorization."""
+        pkce_impl = self._get_pcke_impl()
+        url = await pkce_impl.async_generate_authorize_url(
+            flow_id=self.flow_id
+        )
+
+        LOGGER.debug("External Step - url `%s`", url)
+
+        return self.async_external_step(
+            step_id="desktop_api",
+            url=url,
+            description_placeholders={"release_url": _RELEASE_URL},
+        )
+
+    async def async_step_desktop_api_manual(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Manual path: the user opens the authorization url, then pastes
+        the browser url it redirects to (which fails to load) so Spotcast
+        can exchange the authorization code itself. No relay needed."""
+        if self._manual_auth_url is None:
+            pkce_impl = self._get_pcke_impl()
+            self._manual_auth_url = await pkce_impl.async_generate_authorize_url(
+                flow_id=self.flow_id
+            )
+
+        placeholders = {"authorize_url": self._manual_auth_url}
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="desktop_api_manual",
+                data_schema=self.MANUAL_AUTH_SCHEMA,
+                description_placeholders=placeholders,
+            )
+
+        try:
+            external_data = self._parse_pasted_redirect(
+                user_input["pasted_url"]
+            )
+        except ManualAuthError as exc:
+            return self.async_show_form(
+                step_id="desktop_api_manual",
+                data_schema=self.MANUAL_AUTH_SCHEMA,
+                description_placeholders=placeholders,
+                errors={"base": exc.error_key},
+            )
+
+        try:
+            self.data["desktop_api"] = {
+                "token": await self.async_get_desktop_token(external_data),
+            }
+        except Exception:  # pylint: disable=W0718
+            LOGGER.exception("Failed to exchange the pasted authorization code")
+            return self.async_show_form(
+                step_id="desktop_api_manual",
+                data_schema=self.MANUAL_AUTH_SCHEMA,
+                description_placeholders=placeholders,
+                errors={"base": "token_request_failed"},
+            )
+
+        return await self.async_oauth_create_entry({})
+
+    def _parse_pasted_redirect(self, pasted_url: str) -> dict:
+        """Parses a pasted redirect url into the OAuth external data.
+
+        Raises:
+            ManualAuthError: when the url is missing, malformed, denied,
+                or carries a state that does not match this flow.
+        """
+        query = parse_qs(urlsplit(pasted_url.strip()).query)
+
+        if not query:
+            raise ManualAuthError("invalid_url")
+
+        if "error" in query:
+            raise ManualAuthError("access_denied")
+
+        code = query.get("code", [None])[0]
+        state = query.get("state", [None])[0]
+
+        if code is None:
+            raise ManualAuthError("missing_code")
+
+        decoded_state = _decode_jwt(self.hass, state) if state else None
+
+        if decoded_state is None or decoded_state.get("flow_id") != self.flow_id:
+            raise ManualAuthError("invalid_state")
+
+        return {"code": code, "state": decoded_state}
+
     def _get_pcke_impl(self) -> RelayedOAuth2ImplementationWithPcke:
         """Provide the custom spotcast Pkce oauth implementation."""
         if self._pcke_impl is None:
@@ -188,19 +321,7 @@ class SpotcastFlowHandler(SpotifyFlowHandler, domain=DOMAIN):
             self.data["external_api"] = data
 
         if "desktop_api" not in self.data:
-            pkce_impl = self._get_pcke_impl()
-
-            url = await pkce_impl.async_generate_authorize_url(
-                flow_id=self.flow_id
-            )
-
-            LOGGER.debug("External Step - url `%s`", url)
-
-            return self.async_external_step(
-                step_id="desktop_api",
-                url=url,
-                description_placeholders={"release_url": _RELEASE_URL},
-            )
+            return await self.async_step_desktop_auth()
 
         external_api = self.data["external_api"]
 

--- a/custom_components/spotcast/sessions/oauth_pcke_implementation.py
+++ b/custom_components/spotcast/sessions/oauth_pcke_implementation.py
@@ -1,10 +1,7 @@
 """Custom OAuth2 with PCKE flow that uses a local relay server."""
 
-from base64 import urlsafe_b64encode
-from hashlib import sha256
 from logging import getLogger
 from time import time
-from os import urandom
 
 from homeassistant.helpers.config_entry_oauth2_flow import (
     LocalOAuth2ImplementationWithPkce,
@@ -70,14 +67,3 @@ class RelayedOAuth2ImplementationWithPcke(LocalOAuth2ImplementationWithPkce):
         result: SpotifyTokenResponse = await self._token_request(request_data)
         result["expires_at"] = result.pop("expires_in") + time()
         return result
-
-    @staticmethod
-    def generate_code_verifier(_: int = 128) -> str:
-        """Generate a code verifier."""
-        return urlsafe_b64encode(urandom(64)).rstrip(b"=").decode()
-
-    @staticmethod
-    def compute_code_challenge(code_verifier: str) -> str:
-        """Computes the code challenge."""
-        digest = sha256(code_verifier.encode()).digest()
-        return urlsafe_b64encode(digest).rstrip(b"=").decode()

--- a/custom_components/spotcast/strings.json
+++ b/custom_components/spotcast/strings.json
@@ -16,16 +16,36 @@
                 "title": "Re-authenticate Spotcast",
                 "description": "The Spotcast integration needs to re-authenticate your account."
             },
+            "desktop_auth": {
+                "title": "Desktop authorization",
+                "description": "Spotcast needs a second authorization using the Spotify desktop application identity. Choose how to complete it.",
+                "menu_options": {
+                    "desktop_api_manual": "Paste the redirect URL (recommended, no extra software)",
+                    "desktop_api_auto": "Use the relay server (automatic redirect)"
+                }
+            },
+            "desktop_api_manual": {
+                "title": "Paste the redirect URL",
+                "description": "1. Open [this authorization link]({authorize_url}) and log in and authorize if asked.\n2. Your browser will then try to open `http://127.0.0.1:8080/login...` and show a connection error. This is expected.\n3. Copy the full address from your browser's address bar and paste it below.",
+                "data": {
+                    "pasted_url": "Redirect URL"
+                }
+            },
             "doc_confirm": {
                 "title": "Start Setup",
-                "description": "Please follow the [setup guide]({setup_guide}) before continuing. Confirm when you have started the relay server.",
+                "description": "Please follow the [setup guide]({setup_guide}) before continuing.",
                 "data": {
-                    "confirmed": "I have read the documentation and started the relay server"
+                    "confirmed": "I have read the documentation"
                 }
             }
         },
         "error": {
-            "must_confirm": "You must confirm before proceeding."
+            "must_confirm": "You must confirm before proceeding.",
+            "invalid_url": "That does not look like a valid redirect URL. Copy the full address from your browser's address bar.",
+            "access_denied": "Authorization was denied. Open the link again and allow access.",
+            "missing_code": "The pasted URL does not contain an authorization code. Copy the full address from your browser's address bar.",
+            "invalid_state": "The pasted URL does not match this setup attempt. Restart the setup and try again.",
+            "token_request_failed": "Could not exchange the authorization code with Spotify. Authorization codes are single-use, so open the link again for a fresh one."
         },
         "abort": {
             "connection_error": "Unable to connect to Spotify using the {account_type} credentials. If you are upgrading from v5, note that the configuration process changed completely in v6. Make sure to follow the [installation guide]({release_url}). For more help, [open a ticket]({ticket_url}).",

--- a/custom_components/spotcast/translations/en.json
+++ b/custom_components/spotcast/translations/en.json
@@ -16,16 +16,36 @@
                 "title": "Re-authenticate Spotcast",
                 "description": "The Spotcast integration needs to re-authenticate your account."
             },
+            "desktop_auth": {
+                "title": "Desktop authorization",
+                "description": "Spotcast needs a second authorization using the Spotify desktop application identity. Choose how to complete it.",
+                "menu_options": {
+                    "desktop_api_manual": "Paste the redirect URL (recommended, no extra software)",
+                    "desktop_api_auto": "Use the relay server (automatic redirect)"
+                }
+            },
+            "desktop_api_manual": {
+                "title": "Paste the redirect URL",
+                "description": "1. Open [this authorization link]({authorize_url}) and log in and authorize if asked.\n2. Your browser will then try to open `http://127.0.0.1:8080/login...` and show a connection error. This is expected.\n3. Copy the full address from your browser's address bar and paste it below.",
+                "data": {
+                    "pasted_url": "Redirect URL"
+                }
+            },
             "doc_confirm": {
                 "title": "Start Setup",
-                "description": "Please follow the [setup guide]({setup_guide}) before continuing. Confirm when you have started the relay server.",
+                "description": "Please follow the [setup guide]({setup_guide}) before continuing.",
                 "data": {
-                    "confirmed": "I have read the documentation and started the relay server"
+                    "confirmed": "I have read the documentation"
                 }
             }
         },
         "error": {
-            "must_confirm": "You must confirm before proceeding."
+            "must_confirm": "You must confirm before proceeding.",
+            "invalid_url": "That does not look like a valid redirect URL. Copy the full address from your browser's address bar.",
+            "access_denied": "Authorization was denied. Open the link again and allow access.",
+            "missing_code": "The pasted URL does not contain an authorization code. Copy the full address from your browser's address bar.",
+            "invalid_state": "The pasted URL does not match this setup attempt. Restart the setup and try again.",
+            "token_request_failed": "Could not exchange the authorization code with Spotify. Authorization codes are single-use, so open the link again for a fresh one."
         },
         "abort": {
             "connection_error": "Unable to connect to Spotify using the {account_type} credentials. If you are upgrading from v5, note that the configuration process changed completely in v6. Make sure to follow the [installation guide]({release_url}). For more help, [open a ticket]({ticket_url}).",

--- a/custom_components/spotcast/translations/fr.json
+++ b/custom_components/spotcast/translations/fr.json
@@ -16,16 +16,36 @@
                 "title": "Ré-authentifier Spotcast",
                 "description": "L'intégration Spotcast a besoin de réauthentifier votre compte."
             },
+            "desktop_auth": {
+                "title": "Autorisation via le client de bureau",
+                "description": "Spotcast a besoin d'une seconde autorisation utilisant l'identité de l'application de bureau Spotify. Choisissez comment la réaliser.",
+                "menu_options": {
+                    "desktop_api_manual": "Coller l'URL de redirection (recommandé, sans logiciel supplémentaire)",
+                    "desktop_api_auto": "Utiliser le serveur relais (redirection automatique)"
+                }
+            },
+            "desktop_api_manual": {
+                "title": "Coller l'URL de redirection",
+                "description": "1. Ouvrez [ce lien d'autorisation]({authorize_url}) et connectez-vous puis autorisez si demandé.\n2. Votre navigateur va ensuite tenter d'ouvrir `http://127.0.0.1:8080/login...` et afficher une erreur de connexion. C'est normal.\n3. Copiez l'adresse complète depuis la barre d'adresse de votre navigateur et collez-la ci-dessous.",
+                "data": {
+                    "pasted_url": "URL de redirection"
+                }
+            },
             "doc_confirm": {
                 "title": "Démarrer la configuration",
-                "description": "Veuillez suivre le [guide de configuration]({setup_guide}) avant de continuer. Confirmez que vous avez démarré le serveur relais.",
+                "description": "Veuillez suivre le [guide de configuration]({setup_guide}) avant de continuer.",
                 "data": {
-                    "confirmed": "J'ai lu la documentation et j'ai démarré le serveur relais"
+                    "confirmed": "J'ai lu la documentation"
                 }
             }
         },
         "error": {
-            "must_confirm": "Vous devez confirmer avant de continuer."
+            "must_confirm": "Vous devez confirmer avant de continuer.",
+            "invalid_url": "Cela ne ressemble pas à une URL de redirection valide. Copiez l'adresse complète depuis la barre d'adresse de votre navigateur.",
+            "access_denied": "L'autorisation a été refusée. Ouvrez à nouveau le lien et autorisez l'accès.",
+            "missing_code": "L'URL collée ne contient pas de code d'autorisation. Copiez l'adresse complète depuis la barre d'adresse de votre navigateur.",
+            "invalid_state": "L'URL collée ne correspond pas à cette tentative de configuration. Recommencez la configuration et réessayez.",
+            "token_request_failed": "Impossible d'échanger le code d'autorisation avec Spotify. Les codes d'autorisation sont à usage unique, ouvrez à nouveau le lien pour en obtenir un nouveau."
         },
         "abort": {
             "connection_error": "Erreur de connexion à Spotify avec les informations d'identification {account_type}. Si vous effectuez une mise à jour depuis la v5, notez que le processus de configuration a complètement changé en v6. Merci de suivre le [guide d'installation]({release_url}). Pour de l'aide supplémentaire, [ouvrez un ticket]({ticket_url}).",

--- a/docs/config/spotcast_configuration.md
+++ b/docs/config/spotcast_configuration.md
@@ -1,19 +1,20 @@
 # Spotcast Configuration
 
-This guide walks you through the setup of Spotcast in Home Assistant. The setup has three parts:
+This guide walks you through the setup of Spotcast in Home Assistant. The setup has two parts:
 
 1. Create a Spotify Application (or reuse the one from the official Spotify integration).
-2. Start a small relay server on your computer (only needed during setup).
-3. Run the Spotcast config flow in Home Assistant.
+2. Run the Spotcast config flow in Home Assistant.
+
+During the config flow Spotcast performs two authorizations: a normal one for your Spotify account, and a second one under the identity of the official Spotify desktop application. For the second one you can simply **paste a URL** from your browser (no extra software), or optionally run a small **relay server** on your computer to automate the redirect.
 
 > [!WARNING]
-> Why is a relay server needed at all? Some Spotcast features require permissions that Spotify only grants to its own applications. During setup, Spotcast therefore authenticates one session under the identity of the official Spotify desktop application, and the relay server is needed to hand that authorization over to Home Assistant. Because this method is not officially supported by Spotify, it may stop working without notice if Spotify changes its authentication systems.
+> Why the second authorization at all? Some Spotcast features require permissions that Spotify only grants to its own applications. Spotcast therefore authenticates one session under the identity of the official Spotify desktop application. Because this method is not officially supported by Spotify, it may stop working without notice if Spotify changes its authentication systems.
 
 ## Prerequisites
 
 - A **Spotify Premium** account.
 - Home Assistant `2026.4` or newer, with Spotcast [installed](../../README.md#installation).
-- A computer with a web browser. The relay server (step 2) and the browser used to complete the setup (step 3) **must be on the same computer**.
+- A web browser to complete the authorization.
 
 ## 1. Create a Spotify Application
 
@@ -26,14 +27,71 @@ In order to work with certain parts of the API, Spotcast requires access to the 
 
 1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) and create an app.
 2. In the app settings, add `https://my.home-assistant.io/redirect/oauth` as a **Redirect URI**.
-3. Keep note of your **Client ID** and **Client Secret** for step 3.
+3. Keep note of your **Client ID** and **Client Secret** for step 2.
 
-## 2. Start the relay server
+## 2. Setup the Spotcast Integration in Home Assistant
 
-In order to add the desktop application credentials from Spotify, we must redirect the connection information from your local computer to Home Assistant. This can be achieved by using a relay server on your local computer. This step is necessary because Spotify does not allow (for understandable security reasons) desktop credentials to be redirected to another location than the device making the connection.
+Open Home Assistant and go to: `Settings -> Devices & Services -> + ADD INTEGRATION -> Spotcast` or use this direct link:
+
+[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=spotcast)
+
+Follow these instructions to finalize the setup in Home Assistant:
+
+### 2.1 Application Credentials
+
+> [!TIP]
+> If you already made a Spotcast configuration in the past on this server, this step will not be required and you can skip to [2.2](#22-public-oauth-authorization).
+>
+> If your application credentials for your Spotify Application changed and you need to edit them, Home Assistant doesn't offer you that option when setting an integration with existing application credentials. You need to remove the current credentials manually, which can be done by following [these instructions](https://www.home-assistant.io/integrations/application_credentials/#deleting-application-credentials) from Home Assistant.
+
+Once you see this window below in Home Assistant, provide a name (to your discretion) and provide the Client ID and Client Secret from your Spotify Application created in [Step 1](#1-create-a-spotify-application).
+
+![Application Credential Step Screenshot](../../assets/images/docs/spotcast_configuration/3_1_application_credentials.png)
+
+### 2.2 Public OAuth authorization
+
+This step will authorize your account in your Spotify Application. A new window will appear asking you to link the account to Home Assistant. Ensure the `Your instance URL:` points to your current Home Assistant server and press the `Link account` button.
 
 > [!IMPORTANT]
-> Run the relay server on the **same computer** where you will complete the setup in your web browser, and keep it running until the setup is done. It is only needed during setup (and later for reauthentication).
+> Make sure the correct account is signed in. If Spotify doesn't ask you to log in, it is because a Spotify account is already signed in. If you are trying to set up an account for someone else in your household, make sure their account is the one signed into the browser.
+
+### 2.3 Desktop authorization
+
+Spotcast now asks how you want to provide the second (desktop) authorization. Choose one of the two options.
+
+#### Option A: Paste the redirect URL (recommended)
+
+This option needs no extra software.
+
+1. Select **Paste the redirect URL** in the menu.
+2. Open the authorization link shown on the form and log in / authorize if asked.
+3. Your browser will then try to open an address starting with `http://127.0.0.1:8080/login...` and show a **connection error**. This is expected, because nothing is listening on that address.
+4. Copy the **full address** from your browser's address bar (it contains `?code=...&state=...`) and paste it into the form field, then submit.
+
+Spotcast exchanges the authorization code and completes the setup.
+
+> [!TIP]
+> If you get an error that the code could not be exchanged, open the authorization link again to get a fresh code. Authorization codes are single-use.
+
+#### Option B: Use the relay server (automatic)
+
+If you prefer the browser to be redirected back to Home Assistant automatically, run the [relay server](#optional-relay-server) on the same computer as your browser first, then select **Use the relay server** in the menu and complete the authorization. See [the appendix](#optional-relay-server) for how to start it.
+
+### Done
+
+At this point you should see your Spotify devices and account start to populate in the Home Assistant window.
+
+> [!NOTE]
+> You have completed the Spotcast setup. The same desktop authorization step is required again if you ever need to reauthenticate.
+
+---
+
+## Optional: Relay Server
+
+Instead of pasting the redirect URL manually (Option A above), you can run a small relay server on your computer that redirects the desktop authorization back to Home Assistant automatically (Option B). This is entirely optional.
+
+> [!IMPORTANT]
+> Run the relay server on the **same computer** where you complete the setup in your web browser, and keep it running until the setup is done. It is only needed during setup (and later for reauthentication).
 
 Please follow the instructions for your specific operating system:
 
@@ -172,61 +230,12 @@ Open the Spotcast integration setup in Home Assistant.
 (Press Ctrl+C to cancel.)
 ```
 
-If you see a similar message, you're ready for the next step.
+If you see a similar message, you're ready to select **Use the relay server** in the config flow.
 
 > [!TIP]
 > If the server fails to start because port `8080` is already in use, stop the application using that port and start the relay server again.
 
-
-## 3. Setup the Spotcast Integration in Home Assistant
-
-Open Home Assistant and go to: `Settings -> Devices & Services -> + ADD INTEGRATION -> Spotcast` or use this direct link:
-
-[![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=spotcast)
-
-Follow these instructions to finalize the setup in Home Assistant:
-
-### 3.1 Application Credentials
-
-> [!TIP]
-> If you already made a Spotcast configuration in the past on this server, this step will not be required and you can skip to [3.2](#32-public-oauth-authorization).
->
-> If your application credentials for your Spotify Application changed and you need to edit them, Home Assistant doesn't offer you that option when setting an integration with existing application credentials. You need to remove the current credentials manually, which can be done by following [these instructions](https://www.home-assistant.io/integrations/application_credentials/#deleting-application-credentials) from Home Assistant.
-
-Once you see this window below in Home Assistant, provide a name (to your discretion) and provide the Client ID and Client Secret from your Spotify Application created in [Step 1](#1-create-a-spotify-application).
-
-![Application Credential Step Screenshot](../../assets/images/docs/spotcast_configuration/3_1_application_credentials.png)
-
-### 3.2 Public OAuth authorization
-
-This step will authorize your account in your Spotify Application. A new window will appear asking you to link the account to Home Assistant. Ensure the `Your instance URL:` points to your current Home Assistant server and press the `Link account` button.
-
-> [!IMPORTANT]
-> Make sure the correct account is signed in. If Spotify doesn't ask you to log in, it is because a Spotify account is already signed in. If you are trying to set up an account for someone else in your household, make sure their account is the one signed into the browser.
-
-### 3.3 Desktop Token authorization
-
-A new window will open looking like this:
-
-![Desktop Credential Approval](../../assets/images/docs/spotcast_configuration/3_3_desktop_token.png)
-
-If the account under `Spotify for Desktop` is the account you are trying to set up, press the `Continue to the app` button, otherwise press `Not you?` and connect the proper account.
-
-> [!CAUTION]
-> If the relay server is not running at this point the setup will fail.
-
-The same window as in step [3.2](#32-public-oauth-authorization) will appear. This is normal. This is to redirect your desktop credentials to Home Assistant. You can press the `Link Account` button.
-
-### Done
-
-At this point you should see your Spotify devices and account start to populate in the Home Assistant window.
-
-> [!NOTE]
-> You have completed the Spotcast setup at this point. You can close the relay server by pressing `CTRL+C` in your terminal. The relay server will only be required again for reauthenticating.
-
----
-
-## Optional: Relay Server Configuration
+### Relay Server Configuration
 
 Both relay servers (`relay_server.py` and `relay_server.ps1`) can be configured using CLI arguments to fit specific needs.
 
@@ -234,19 +243,19 @@ Both relay servers (`relay_server.py` and `relay_server.ps1`) can be configured 
 | --------------------- | ------------------------------------------------------------------------------------ | --------------------------------------------- |
 | `-r` `--redirect-url` | Redirects OAuth to your Home Assistant server (if not using `my.home-assistant.io`)  | `https://my.home-assistant.io/redirect/oauth` |
 
-### Example: One-Step Install with Custom Redirect (Python)
+#### Example: One-Step Install with Custom Redirect (Python)
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Mincka/spotcast/main/scripts/relay_server.py | python - -r http://<your-home-assistant-server>
 ```
 
-### Example: Manual Script with Custom Redirect (Python)
+#### Example: Manual Script with Custom Redirect (Python)
 
 ```bash
 python relay_server.py -r http://<your-home-assistant-server>
 ```
 
-### Example: Custom Redirect (PowerShell)
+#### Example: Custom Redirect (PowerShell)
 
 When piping the script with `iex`, set the `$redirectUrl` variable first; when running the downloaded file, use the `-r` argument:
 

--- a/test/config_flow_classes/config_flow_handler/test_async_oauth_create_entry.py
+++ b/test/config_flow_classes/config_flow_handler/test_async_oauth_create_entry.py
@@ -18,34 +18,21 @@ from custom_components.spotcast.config_flow_classes.config_flow_handler \
 from test.config_flow_classes.config_flow_handler import TEST_MODULE
 
 
-class TestExternalApiEntry(IsolatedAsyncioTestCase):
+class TestDesktopAuthMenu(IsolatedAsyncioTestCase):
 
     @patch.object(
         SpotcastFlowHandler,
-        "_get_pcke_impl",
+        "async_show_menu",
         new_callable=MagicMock,
     )
-    @patch.object(
-        SpotcastFlowHandler,
-        "async_external_step",
-        new_callable=MagicMock,
-    )
-    async def asyncSetUp(self, mock_external: AsyncMock, mock_pcke: MagicMock):
-
-        mock_pcke.return_value = MagicMock(
-            spec=RelayedOAuth2ImplementationWithPcke,
-        )
+    async def asyncSetUp(self, mock_menu: MagicMock):
 
         self.mocks = {
             "hass": MagicMock(spec=HomeAssistant),
-            "external": mock_external,
-            "pcke": mock_pcke.return_value
+            "menu": mock_menu,
         }
 
         self.mocks["hass"].data = {}
-        self.mocks["pcke"].async_generate_authorize_url = AsyncMock()
-        self.mocks["pcke"].async_generate_authorize_url\
-            .return_value = "https://foo.bar"
 
         self.handler = SpotcastFlowHandler()
         self.handler.hass = self.mocks["hass"]
@@ -56,14 +43,11 @@ class TestExternalApiEntry(IsolatedAsyncioTestCase):
     def test_data_added_to_external_api(self):
         self.assertEqual(self.handler.data, {"external_api": {"foo": "bar"}})
 
-    def test_external_step_called(self):
+    def test_menu_shown(self):
         try:
-            self.mocks["external"].assert_called_with(
-                step_id="desktop_api",
-                url="https://foo.bar",
-                description_placeholders={
-                    "release_url": "https://github.com/Mincka/spotcast/blob/main/docs/config/spotcast_configuration.md",
-                },
+            self.mocks["menu"].assert_called_with(
+                step_id="desktop_auth",
+                menu_options=["desktop_api_manual", "desktop_api_auto"],
             )
         except AssertionError as exc:
             self.fail(exc)

--- a/test/config_flow_classes/config_flow_handler/test_async_step_desktop_api_auto.py
+++ b/test/config_flow_classes/config_flow_handler/test_async_step_desktop_api_auto.py
@@ -1,0 +1,56 @@
+"""Module to test the async_step_desktop_api_auto step"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.config_flow_classes.config_flow_handler \
+    import (
+        SpotcastFlowHandler,
+        RelayedOAuth2ImplementationWithPcke,
+    )
+
+
+class TestAutoExternalStep(IsolatedAsyncioTestCase):
+
+    @patch.object(
+        SpotcastFlowHandler,
+        "_get_pcke_impl",
+        new_callable=MagicMock,
+    )
+    @patch.object(
+        SpotcastFlowHandler,
+        "async_external_step",
+        new_callable=MagicMock,
+    )
+    async def asyncSetUp(self, mock_external: MagicMock, mock_pcke: MagicMock):
+
+        mock_pcke.return_value = MagicMock(
+            spec=RelayedOAuth2ImplementationWithPcke,
+        )
+        mock_pcke.return_value.async_generate_authorize_url = AsyncMock(
+            return_value="https://foo.bar"
+        )
+
+        self.mocks = {
+            "external": mock_external,
+            "pcke": mock_pcke.return_value,
+        }
+
+        self.handler = SpotcastFlowHandler()
+        self.handler.flow_id = "12345"
+
+        self.result = await self.handler.async_step_desktop_api_auto()
+
+    def test_external_step_called(self):
+        try:
+            self.mocks["external"].assert_called_with(
+                step_id="desktop_api",
+                url="https://foo.bar",
+                description_placeholders={
+                    "release_url": "https://github.com/Mincka/spotcast/blob/main/docs/config/spotcast_configuration.md",
+                },
+            )
+        except AssertionError as exc:
+            self.fail(exc)
+
+        self.assertIs(self.result, self.mocks["external"].return_value)

--- a/test/config_flow_classes/config_flow_handler/test_async_step_desktop_api_manual.py
+++ b/test/config_flow_classes/config_flow_handler/test_async_step_desktop_api_manual.py
@@ -1,0 +1,211 @@
+"""Module to test the async_step_desktop_api_manual step"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.spotcast.config_flow_classes.config_flow_handler \
+    import (
+        SpotcastFlowHandler,
+        RelayedOAuth2ImplementationWithPcke,
+    )
+
+from test.config_flow_classes.config_flow_handler import TEST_MODULE
+
+VALID_STATE = {
+    "flow_id": "12345",
+    "redirect_uri": "http://127.0.0.1:8080/login",
+}
+
+
+class TestFormShown(IsolatedAsyncioTestCase):
+
+    @patch.object(
+        SpotcastFlowHandler,
+        "_get_pcke_impl",
+        new_callable=MagicMock,
+    )
+    @patch.object(
+        SpotcastFlowHandler,
+        "async_show_form",
+        new_callable=MagicMock,
+    )
+    async def asyncSetUp(self, mock_form: MagicMock, mock_pcke: MagicMock):
+
+        mock_pcke.return_value = MagicMock(
+            spec=RelayedOAuth2ImplementationWithPcke,
+        )
+        mock_pcke.return_value.async_generate_authorize_url = AsyncMock(
+            return_value="https://auth.url"
+        )
+
+        self.mocks = {"form": mock_form}
+
+        self.handler = SpotcastFlowHandler()
+        self.handler.flow_id = "12345"
+
+        await self.handler.async_step_desktop_api_manual()
+
+    def test_form_shown_with_authorize_url(self):
+        kwargs = self.mocks["form"].call_args.kwargs
+        self.assertEqual(kwargs["step_id"], "desktop_api_manual")
+        self.assertEqual(
+            kwargs["description_placeholders"],
+            {"authorize_url": "https://auth.url"},
+        )
+
+
+class TestHappyPath(IsolatedAsyncioTestCase):
+
+    @patch.object(
+        SpotcastFlowHandler,
+        "async_oauth_create_entry",
+        new_callable=AsyncMock,
+    )
+    @patch.object(
+        SpotcastFlowHandler,
+        "async_get_desktop_token",
+        new_callable=AsyncMock,
+    )
+    @patch(f"{TEST_MODULE}._decode_jwt")
+    async def asyncSetUp(
+        self,
+        mock_decode: MagicMock,
+        mock_token: AsyncMock,
+        mock_create: AsyncMock,
+    ):
+
+        mock_decode.return_value = dict(VALID_STATE)
+        mock_token.return_value = {"access_token": "tok"}
+
+        self.mocks = {
+            "decode": mock_decode,
+            "token": mock_token,
+            "create": mock_create,
+        }
+
+        self.handler = SpotcastFlowHandler()
+        self.handler.hass = MagicMock(spec=HomeAssistant)
+        self.handler.flow_id = "12345"
+        self.handler.data = {}
+        self.handler._manual_auth_url = "https://auth.url"
+
+        self.result = await self.handler.async_step_desktop_api_manual({
+            "pasted_url": (
+                "http://127.0.0.1:8080/login?code=the-code&state=the-state"
+            ),
+        })
+
+    def test_token_exchanged_with_code_and_state(self):
+        try:
+            self.mocks["token"].assert_called_once_with(
+                {"code": "the-code", "state": VALID_STATE},
+            )
+        except AssertionError as exc:
+            self.fail(exc)
+
+    def test_desktop_token_stored(self):
+        self.assertEqual(
+            self.handler.data["desktop_api"],
+            {"token": {"access_token": "tok"}},
+        )
+
+    def test_oauth_create_entry_called(self):
+        try:
+            self.mocks["create"].assert_called_once_with({})
+        except AssertionError as exc:
+            self.fail(exc)
+
+        self.assertIs(self.result, self.mocks["create"].return_value)
+
+
+class _ManualErrorCase(IsolatedAsyncioTestCase):
+    """Base for the error-path tests. Subclasses set PASTED, DECODE and
+    TOKEN_RAISES then assert on EXPECTED_ERROR."""
+
+    PASTED = ""
+    DECODE = None
+    TOKEN_RAISES = False
+    EXPECTED_ERROR = ""
+
+    async def _run(self):
+        with patch.object(
+            SpotcastFlowHandler, "async_show_form", new_callable=MagicMock,
+        ) as mock_form, patch.object(
+            SpotcastFlowHandler,
+            "async_get_desktop_token",
+            new_callable=AsyncMock,
+        ) as mock_token, patch(
+            f"{TEST_MODULE}._decode_jwt", return_value=self.DECODE,
+        ):
+            if self.TOKEN_RAISES:
+                mock_token.side_effect = ValueError("boom")
+
+            handler = SpotcastFlowHandler()
+            handler.hass = MagicMock(spec=HomeAssistant)
+            handler.flow_id = "12345"
+            handler.data = {}
+            handler._manual_auth_url = "https://auth.url"
+
+            await handler.async_step_desktop_api_manual({
+                "pasted_url": self.PASTED,
+            })
+
+            return mock_form.call_args.kwargs
+
+    async def _assert_error(self):
+        kwargs = await self._run()
+        self.assertEqual(kwargs["errors"], {"base": self.EXPECTED_ERROR})
+
+
+class TestInvalidUrl(_ManualErrorCase):
+    PASTED = "not-a-url"
+    EXPECTED_ERROR = "invalid_url"
+
+    async def test_error(self):
+        await self._assert_error()
+
+
+class TestAccessDenied(_ManualErrorCase):
+    PASTED = "http://127.0.0.1:8080/login?error=access_denied&state=x"
+    EXPECTED_ERROR = "access_denied"
+
+    async def test_error(self):
+        await self._assert_error()
+
+
+class TestMissingCode(_ManualErrorCase):
+    PASTED = "http://127.0.0.1:8080/login?state=x"
+    EXPECTED_ERROR = "missing_code"
+
+    async def test_error(self):
+        await self._assert_error()
+
+
+class TestInvalidState(_ManualErrorCase):
+    PASTED = "http://127.0.0.1:8080/login?code=abc&state=bad"
+    DECODE = None
+    EXPECTED_ERROR = "invalid_state"
+
+    async def test_error(self):
+        await self._assert_error()
+
+
+class TestFlowIdMismatch(_ManualErrorCase):
+    PASTED = "http://127.0.0.1:8080/login?code=abc&state=other"
+    DECODE = {"flow_id": "other-flow", "redirect_uri": "x"}
+    EXPECTED_ERROR = "invalid_state"
+
+    async def test_error(self):
+        await self._assert_error()
+
+
+class TestTokenRequestFailed(_ManualErrorCase):
+    PASTED = "http://127.0.0.1:8080/login?code=abc&state=good"
+    DECODE = dict(VALID_STATE)
+    TOKEN_RAISES = True
+    EXPECTED_ERROR = "token_request_failed"
+
+    async def test_error(self):
+        await self._assert_error()


### PR DESCRIPTION
## Summary
The desktop authorization step previously **required** running a local relay server to redirect the browser back to Home Assistant. This adds a manual alternative that needs no extra software.

## How the manual path works
1. The config flow now shows a menu: **Paste the redirect URL** (default) or **Use the relay server**.
2. On the manual path, the user opens the authorization link, and the browser lands on the unreachable `http://127.0.0.1:8080/login?code=...&state=...` (a connection error, which is expected).
3. The user pastes that full URL into the form. Spotcast parses the code and state, decodes the state JWT and verifies it belongs to this flow (`_decode_jwt` + `flow_id` check), then exchanges the authorization code itself.

Clear form errors are shown for a malformed URL, a denied authorization, a missing code, a state that doesn't match the flow, or a failed code exchange (codes are single-use).

## Also
- The relay-based path is unchanged and available as the second menu option.
- Setup guide restructured: manual paste is the primary path, the relay server moves to an optional appendix. README setup wording updated.
- Removed dead `generate_code_verifier`/`compute_code_challenge` overrides in the PKCE implementation (the base class calls its own class-qualified statics).
- Reworded the strings that mandated a running relay server.

## Tests
Full suite green (625), pylint 9.59. New coverage: the desktop-auth menu, the auto external step, and the manual step (form shown, happy path with a decoded state, and each error key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)