### PR TITLE
Add a current-playlist sensor resolved via the internal endpoint (#569)

### DIFF
--- a/custom_components/spotcast/coordinator.py
+++ b/custom_components/spotcast/coordinator.py
@@ -114,12 +114,15 @@ class SpotcastCoordinator(DataUpdateCoordinator[dict]):
 
         await self._async_update_device_manager()
 
+        context_name = await self.account.async_get_current_context_name()
+
         return {
             "profile": profile,
             "devices": devices,
             "playback_state": playback_state,
             "playlists_count": playlists_count,
             "liked_songs_count": liked_songs_count,
+            "context_name": context_name,
         }
 
     async def _async_update_device_manager(self):

--- a/custom_components/spotcast/sensor/__init__.py
+++ b/custom_components/spotcast/sensor/__init__.py
@@ -33,6 +33,9 @@ from custom_components.spotcast.sensor.spotify_followers_sensor import (
 from custom_components.spotcast.sensor.spotify_account_type_sensor import (
     SpotifyAccountTypeSensor
 )
+from custom_components.spotcast.sensor.spotify_current_context_sensor import (
+    SpotifyCurrentContextSensor
+)
 
 LOGGER = getLogger(__name__)
 SENSORS = (
@@ -43,6 +46,7 @@ SENSORS = (
     SpotifyProductSensor,
     SpotifyFollowersSensor,
     SpotifyAccountTypeSensor,
+    SpotifyCurrentContextSensor,
 )
 
 

--- a/custom_components/spotcast/sensor/spotify_current_context_sensor.py
+++ b/custom_components/spotcast/sensor/spotify_current_context_sensor.py
@@ -1,0 +1,58 @@
+"""The SpotifyCurrentContextSensor object
+
+Classes:
+    - SpotifyCurrentContextSensor
+"""
+
+from logging import getLogger
+
+from homeassistant.const import EntityCategory
+
+from custom_components.spotcast.sensor.abstract_sensor import SpotcastSensor
+
+LOGGER = getLogger(__name__)
+
+
+class SpotifyCurrentContextSensor(SpotcastSensor):
+    """A Home Assistant sensor reporting the name of the playlist
+    currently playing on a Spotify Account.
+
+    The name is resolved through Spotify's unofficial internal endpoint,
+    so it also works for editorial and algorithmic playlists that carry
+    no name through the public Web API. It reports the inactive state
+    when nothing is playing or the context is not a playlist.
+
+    Methods:
+        - _update_from_coordinator
+    """
+
+    GENERIC_NAME = "Spotify Current Playlist"
+    ICON = "mdi:playlist-music"
+    ENTITY_CATEGORY = EntityCategory.DIAGNOSTIC
+    STATE_CLASS = None
+
+    def _update_from_coordinator(self):
+        """Updates the current playlist name from the coordinator data"""
+
+        name = self.coordinator.data.get("context_name")
+
+        if not name:
+            self._attr_state = self.INACTIVE_STATE
+            self._attributes = self._default_attributes
+            return
+
+        context = (
+            self.coordinator.data.get("playback_state") or {}
+        ).get("context") or {}
+
+        LOGGER.debug(
+            "Current playlist for account `%s` is `%s`",
+            self.account.name,
+            name,
+        )
+
+        self._attr_state = name
+        self._attributes = {
+            "context_uri": context.get("uri"),
+            "context_type": context.get("type"),
+        }

--- a/custom_components/spotcast/spotify/account.py
+++ b/custom_components/spotcast/spotify/account.py
@@ -33,6 +33,7 @@ from custom_components.spotcast.utils import ensure_default_data, copy_to_dict
 from custom_components.spotcast.spotify.dataset import Dataset
 from custom_components.spotcast.spotify.internal_api import (
     async_get_playlist_length,
+    async_get_playlist_name,
 )
 from custom_components.spotcast.spotify.search_query import SearchQuery
 from custom_components.spotcast.spotify.utils import select_image_url
@@ -194,6 +195,7 @@ class SpotifyAccount:
 
         self._datasets: dict[str, Dataset] = {}
         self._last_playback_state = {}
+        self._context_name_cache: tuple[str | None, str | None] = (None, None)
         self._playback_store = Store(
             hass,
             1,
@@ -391,6 +393,38 @@ class SpotifyAccount:
                 endpoint is unavailable (callers should fall back)
         """
         return await async_get_playlist_length(self, uri)
+
+    async def async_get_current_context_name(self) -> str | None:
+        """Returns the human-readable name of the playlist currently
+        playing on the account.
+
+        The context uri comes from the public playback state, but its
+        name is resolved through the unofficial internal endpoint so it
+        also works for editorial/algorithmic playlists. The last
+        resolved name is cached per context uri to avoid a lookup on
+        every refresh.
+
+        Returns:
+            - str | None: the playlist name, or None when nothing is
+                playing, the context is not a playlist, or the name
+                could not be resolved
+        """
+        playback = self.playback_state
+        context = playback.get("context") if isinstance(playback, dict) else None
+        uri = context.get("uri") if isinstance(context, dict) else None
+
+        if not uri or ":playlist:" not in uri:
+            return None
+
+        if uri == self._context_name_cache[0]:
+            return self._context_name_cache[1]
+
+        name = await async_get_playlist_name(self, uri)
+
+        if name is not None:
+            self._context_name_cache = (uri, name)
+
+        return name
 
     async def async_ensure_tokens_valid(
         self,

--- a/custom_components/spotcast/spotify/internal_api.py
+++ b/custom_components/spotcast/spotify/internal_api.py
@@ -8,6 +8,7 @@ raising, so callers can fall back to supported behaviour.
 
 Functions:
     async_get_playlist_length
+    async_get_playlist_name
 """
 
 from logging import getLogger
@@ -20,13 +21,11 @@ LOGGER = getLogger(__name__)
 SPCLIENT_BASE = "https://spclient.wg.spotify.com"
 
 
-async def async_get_playlist_length(account, uri: str) -> int | None:
-    """Returns the number of tracks in a playlist using the internal
-    playlist metadata endpoint.
+async def _async_get_playlist_metadata(account, uri: str) -> dict | None:
+    """Fetches a playlist's metadata document from the internal endpoint.
 
     Unlike the public Web API, this endpoint also resolves Spotify's own
-    editorial/algorithmic playlists (the ones that 404 publicly), so it
-    can supply a real track count for a random start offset.
+    editorial/algorithmic playlists (the ones that 404 publicly).
 
     Args:
         - account(SpotifyAccount): the account whose desktop token
@@ -34,8 +33,8 @@ async def async_get_playlist_length(account, uri: str) -> int | None:
         - uri(str): the playlist uri or bare id
 
     Returns:
-        - int | None: the track count, or None if it could not be
-            determined through the internal endpoint
+        - dict | None: the parsed metadata, or None if it could not be
+            retrieved through the internal endpoint
     """
     playlist_id = uri.rsplit(":", 1)[-1]
     url = f"{SPCLIENT_BASE}/playlist/v2/playlist/{playlist_id}/metadata"
@@ -44,7 +43,7 @@ async def async_get_playlist_length(account, uri: str) -> int | None:
         token = await account.async_get_token("private")
     except Exception as exc:  # pylint: disable=broad-except
         # The desktop session is optional and its failures must never
-        # break a playback request; fall back to pseudo-random instead.
+        # break the caller; fall back instead.
         LOGGER.debug("Desktop token unavailable for internal API: %s", exc)
         return None
 
@@ -76,5 +75,50 @@ async def async_get_playlist_length(account, uri: str) -> int | None:
         )
         return None
 
-    length = data.get("length") if isinstance(data, dict) else None
+    return data if isinstance(data, dict) else None
+
+
+async def async_get_playlist_length(account, uri: str) -> int | None:
+    """Returns the number of tracks in a playlist using the internal
+    playlist metadata endpoint.
+
+    Args:
+        - account(SpotifyAccount): the account whose desktop token
+            authorises the call
+        - uri(str): the playlist uri or bare id
+
+    Returns:
+        - int | None: the track count, or None if it could not be
+            determined through the internal endpoint
+    """
+    data = await _async_get_playlist_metadata(account, uri)
+
+    if data is None:
+        return None
+
+    length = data.get("length")
     return length if isinstance(length, int) else None
+
+
+async def async_get_playlist_name(account, uri: str) -> str | None:
+    """Returns the human-readable name of a playlist using the internal
+    playlist metadata endpoint. Resolves editorial/algorithmic playlists
+    that carry no name through the public Web API.
+
+    Args:
+        - account(SpotifyAccount): the account whose desktop token
+            authorises the call
+        - uri(str): the playlist uri or bare id
+
+    Returns:
+        - str | None: the playlist name, or None if it could not be
+            determined through the internal endpoint
+    """
+    data = await _async_get_playlist_metadata(account, uri)
+
+    if data is None:
+        return None
+
+    attributes = data.get("attributes")
+    name = attributes.get("name") if isinstance(attributes, dict) else None
+    return name if isinstance(name, str) and name != "" else None

--- a/test/coordinator/test_async_update_data.py
+++ b/test/coordinator/test_async_update_data.py
@@ -38,6 +38,8 @@ class TestSuccessfulUpdate(IsolatedAsyncioTestCase):
             .return_value = {"device": {"id": "device"}}
         self.mocks["account"].async_playlists_count.return_value = 10
         self.mocks["account"].async_liked_songs_count.return_value = 5
+        self.mocks["account"].async_get_current_context_name\
+            .return_value = "My Playlist"
 
         self.mocks["device_manager"].async_update = AsyncMock()
 
@@ -67,6 +69,7 @@ class TestSuccessfulUpdate(IsolatedAsyncioTestCase):
                 "playback_state": {"device": {"id": "device"}},
                 "playlists_count": 10,
                 "liked_songs_count": 5,
+                "context_name": "My Playlist",
             },
         )
 

--- a/test/sensor/spotify_current_context_sensor/test_update_from_coordinator.py
+++ b/test/sensor/spotify_current_context_sensor/test_update_from_coordinator.py
@@ -1,0 +1,91 @@
+"""Module to test the _update_from_coordinator function"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from homeassistant.const import STATE_OFF
+
+from custom_components.spotcast.coordinator import SpotcastCoordinator
+from custom_components.spotcast.spotify import SpotifyAccount
+from custom_components.spotcast.sensor.spotify_current_context_sensor import (
+    SpotifyCurrentContextSensor,
+)
+
+
+def _build_sensor(data: dict) -> SpotifyCurrentContextSensor:
+    coordinator = MagicMock(spec=SpotcastCoordinator)
+    coordinator.account = MagicMock(spec=SpotifyAccount)
+    coordinator.account.name = "Dummy Account"
+    coordinator.account.id = "dummy_account"
+    coordinator.data = data
+
+    sensor = SpotifyCurrentContextSensor(coordinator)
+    sensor._update_from_coordinator()
+    return sensor
+
+
+class TestPlaylistPlaying(TestCase):
+
+    def setUp(self):
+        self.sensor = _build_sensor(
+            {
+                "context_name": "Today's Top Hits",
+                "playback_state": {
+                    "context": {
+                        "uri": "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+                        "type": "playlist",
+                    }
+                },
+            }
+        )
+
+    def test_state_is_playlist_name(self):
+        self.assertEqual(self.sensor.state, "Today's Top Hits")
+
+    def test_attributes_expose_context(self):
+        self.assertEqual(
+            self.sensor.extra_state_attributes,
+            {
+                "context_uri": "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+                "context_type": "playlist",
+            },
+        )
+
+
+class TestNothingResolved(TestCase):
+
+    def setUp(self):
+        self.sensor = _build_sensor(
+            {
+                "context_name": None,
+                "playback_state": {},
+            }
+        )
+
+    def test_state_is_inactive(self):
+        self.assertEqual(self.sensor.state, STATE_OFF)
+
+    def test_attributes_cleared(self):
+        self.assertIsNone(self.sensor.extra_state_attributes)
+
+
+class TestMissingPlaybackContext(TestCase):
+    """A resolved name with a playback_state that has no context still
+    reports the name and tolerates the missing context gracefully."""
+
+    def setUp(self):
+        self.sensor = _build_sensor(
+            {
+                "context_name": "RapCaviar",
+                "playback_state": {},
+            }
+        )
+
+    def test_state_is_playlist_name(self):
+        self.assertEqual(self.sensor.state, "RapCaviar")
+
+    def test_attributes_have_none_context(self):
+        self.assertEqual(
+            self.sensor.extra_state_attributes,
+            {"context_uri": None, "context_type": None},
+        )

--- a/test/spotify/account/test_async_get_current_context_name.py
+++ b/test/spotify/account/test_async_get_current_context_name.py
@@ -1,0 +1,162 @@
+"""Module to test the async_get_current_context_name function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch, PropertyMock
+
+from custom_components.spotcast.spotify.account import (
+    SpotifyAccount,
+    PublicSession,
+    DesktopSession,
+    HomeAssistant,
+    Spotify,
+    Store,
+)
+
+from test.spotify.account import TEST_MODULE
+
+
+class _AccountCase(IsolatedAsyncioTestCase):
+
+    PLAYBACK = {}
+
+    @patch(
+        f"{TEST_MODULE}.async_get_playlist_name",
+        new_callable=AsyncMock,
+    )
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_spotify: MagicMock,
+        mock_store: MagicMock,
+        mock_name: AsyncMock,
+    ):
+        mock_name.return_value = "Resolved Name"
+        self.mock_name = mock_name
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=MagicMock(spec=HomeAssistant),
+            public_session=MagicMock(spec=PublicSession),
+            private_session=MagicMock(spec=DesktopSession),
+            is_default=True,
+        )
+
+        self.patcher = patch.object(
+            SpotifyAccount,
+            "playback_state",
+            new_callable=PropertyMock,
+            return_value=self.PLAYBACK,
+        )
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+        self.result = await self.account.async_get_current_context_name()
+
+
+class TestPlaylistContext(_AccountCase):
+
+    PLAYBACK = {
+        "context": {
+            "uri": "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+            "type": "playlist",
+        }
+    }
+
+    def test_name_resolved(self):
+        self.assertEqual(self.result, "Resolved Name")
+
+    def test_helper_called_with_uri(self):
+        try:
+            self.mock_name.assert_called_once_with(
+                self.account, "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"
+            )
+        except AssertionError as exc:
+            self.fail(exc)
+
+
+class TestAlbumContext(_AccountCase):
+
+    PLAYBACK = {
+        "context": {
+            "uri": "spotify:album:1234",
+            "type": "album",
+        }
+    }
+
+    def test_returns_none(self):
+        self.assertIsNone(self.result)
+
+    def test_helper_not_called(self):
+        try:
+            self.mock_name.assert_not_called()
+        except AssertionError as exc:
+            self.fail(exc)
+
+
+class TestNoContext(_AccountCase):
+
+    PLAYBACK = {}
+
+    def test_returns_none(self):
+        self.assertIsNone(self.result)
+
+    def test_helper_not_called(self):
+        try:
+            self.mock_name.assert_not_called()
+        except AssertionError as exc:
+            self.fail(exc)
+
+
+class TestCachedByUri(IsolatedAsyncioTestCase):
+    """A second lookup for the same context uri reuses the cached name
+    without hitting the internal endpoint again."""
+
+    @patch(
+        f"{TEST_MODULE}.async_get_playlist_name",
+        new_callable=AsyncMock,
+    )
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_spotify: MagicMock,
+        mock_store: MagicMock,
+        mock_name: AsyncMock,
+    ):
+        mock_name.return_value = "Cached Name"
+        self.mock_name = mock_name
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=MagicMock(spec=HomeAssistant),
+            public_session=MagicMock(spec=PublicSession),
+            private_session=MagicMock(spec=DesktopSession),
+            is_default=True,
+        )
+
+        playback = {
+            "context": {
+                "uri": "spotify:playlist:foo",
+                "type": "playlist",
+            }
+        }
+
+        with patch.object(
+            SpotifyAccount,
+            "playback_state",
+            new_callable=PropertyMock,
+            return_value=playback,
+        ):
+            self.first = await self.account.async_get_current_context_name()
+            self.second = await self.account.async_get_current_context_name()
+
+    def test_both_return_name(self):
+        self.assertEqual(self.first, "Cached Name")
+        self.assertEqual(self.second, "Cached Name")
+
+    def test_helper_called_once(self):
+        try:
+            self.mock_name.assert_called_once()
+        except AssertionError as exc:
+            self.fail(exc)

--- a/test/spotify/internal_api/test_async_get_playlist_name.py
+++ b/test/spotify/internal_api/test_async_get_playlist_name.py
@@ -1,0 +1,152 @@
+"""Module to test the async_get_playlist_name function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.spotify.internal_api import (
+    async_get_playlist_name,
+    SPCLIENT_BASE,
+)
+
+from test.spotify.internal_api import TEST_MODULE
+
+
+def _account_with_response(response: MagicMock):
+    account = MagicMock()
+    account.async_get_token = AsyncMock(return_value="desktop-token")
+    session = MagicMock()
+    session.get = AsyncMock(return_value=response)
+    return account, session
+
+
+class TestNameResolved(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_get_clientsession", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_session: MagicMock):
+
+        response = MagicMock()
+        response.status = 200
+        response.json = AsyncMock(
+            return_value={
+                "length": 50,
+                "attributes": {
+                    "name": "Today's Top Hits",
+                    "description": "The hottest 50.",
+                },
+            }
+        )
+
+        self.account, self.session = _account_with_response(response)
+        mock_session.return_value = self.session
+
+        self.result = await async_get_playlist_name(
+            self.account,
+            "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
+        )
+
+    def test_name_returned(self):
+        self.assertEqual(self.result, "Today's Top Hits")
+
+    def test_metadata_endpoint_called(self):
+        expected = (
+            f"{SPCLIENT_BASE}/playlist/v2/playlist/"
+            "37i9dQZF1DXcBWIGoYBM5M/metadata"
+        )
+        try:
+            self.session.get.assert_called_once_with(
+                expected,
+                headers={
+                    "authorization": "Bearer desktop-token",
+                    "accept": "application/json",
+                },
+            )
+        except AssertionError as exc:
+            self.fail(exc)
+
+
+class TestMissingName(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_get_clientsession", new_callable=MagicMock)
+    async def test_no_attributes_returns_none(self, mock_session: MagicMock):
+
+        response = MagicMock()
+        response.status = 200
+        response.json = AsyncMock(return_value={"length": 50})
+
+        account, session = _account_with_response(response)
+        mock_session.return_value = session
+
+        result = await async_get_playlist_name(
+            account, "spotify:playlist:foo"
+        )
+
+        self.assertIsNone(result)
+
+    @patch(f"{TEST_MODULE}.async_get_clientsession", new_callable=MagicMock)
+    async def test_empty_name_returns_none(self, mock_session: MagicMock):
+
+        response = MagicMock()
+        response.status = 200
+        response.json = AsyncMock(return_value={"attributes": {"name": ""}})
+
+        account, session = _account_with_response(response)
+        mock_session.return_value = session
+
+        result = await async_get_playlist_name(
+            account, "spotify:playlist:foo"
+        )
+
+        self.assertIsNone(result)
+
+    @patch(f"{TEST_MODULE}.async_get_clientsession", new_callable=MagicMock)
+    async def test_name_not_str_returns_none(self, mock_session: MagicMock):
+
+        response = MagicMock()
+        response.status = 200
+        response.json = AsyncMock(
+            return_value={"attributes": {"name": 1234}}
+        )
+
+        account, session = _account_with_response(response)
+        mock_session.return_value = session
+
+        result = await async_get_playlist_name(
+            account, "spotify:playlist:foo"
+        )
+
+        self.assertIsNone(result)
+
+
+class TestUnavailable(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.async_get_clientsession", new_callable=MagicMock)
+    async def test_non_ok_status_returns_none(self, mock_session: MagicMock):
+
+        response = MagicMock()
+        response.status = 404
+        response.json = AsyncMock(return_value={"attributes": {"name": "x"}})
+
+        account, session = _account_with_response(response)
+        mock_session.return_value = session
+
+        result = await async_get_playlist_name(
+            account, "spotify:playlist:foo"
+        )
+
+        self.assertIsNone(result)
+        response.json.assert_not_called()
+
+    @patch(f"{TEST_MODULE}.async_get_clientsession", new_callable=MagicMock)
+    async def test_token_unavailable_returns_none(
+        self, mock_session: MagicMock
+    ):
+
+        account = MagicMock()
+        account.async_get_token = AsyncMock(side_effect=RuntimeError("boom"))
+
+        result = await async_get_playlist_name(
+            account, "spotify:playlist:foo"
+        )
+
+        self.assertIsNone(result)
+        mock_session.assert_not_called()


### PR DESCRIPTION
## What

Adds a **"Spotify Current Playlist"** sensor per account, reporting the name of the playlist currently playing. Closes the long-standing request in [fondberg/spotcast#569](https://github.com/fondberg/spotcast/issues/569).

## How

- The context URI comes from the public playback state the coordinator already polls.
- Its **name** is resolved through Spotify's unofficial internal metadata endpoint (`spclient.wg.spotify.com/playlist/v2/playlist/{id}/metadata`, desktop token), which — unlike the public Web API — also resolves editorial/algorithmic playlists. This reuses the helper added for the editorial random-start feature.
- `internal_api.async_get_playlist_name` shares a single metadata fetch with `async_get_playlist_length`.
- `account.async_get_current_context_name` handles playlist contexts only and caches the resolved name per context URI, so it does not hit the endpoint on every 30s refresh.
- The coordinator adds `context_name` to its data; the sensor exposes `context_uri`/`context_type` as attributes.

## Graceful fallback

No dealer websocket is involved (unlike smart shuffle / live connect-state). Every failure path — no desktop token, network error, non-200, bad JSON, missing/empty name, non-playlist context, nothing playing — degrades to the inactive state. Nothing routes through `api.spotify.com` (which 429s the desktop token).

## Tests

- `internal_api`: name resolved, missing/empty/non-str name, non-200, token unavailable.
- `account`: playlist context resolves, album/no-context returns None, per-URI caching (helper called once).
- coordinator: `context_name` added to data.
- sensor: playlist name state + attributes, inactive when unresolved, missing-context tolerance.

Full suite green (675 tests); pylint 9.59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)