### PR TITLE
Drop the removed view endpoint from the architecture doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -348,9 +348,9 @@ similar) applied through `async_apply_extras`.
 
 Spotcast registers a set of Home Assistant WebSocket commands
 (`websocket/`) for use by frontend cards: `accounts`, `devices`,
-`cast_devices`, `categories`, `playlists`, `tracks`, `liked_media`,
-`search`, `view`, and `player`. These are read-oriented endpoints backed
-by the same account datasets, letting a custom dashboard query the account
+`castdevices`, `categories`, `playlists`, `tracks`, `liked_media`,
+`search`, and `player`. These are read-oriented endpoints backed by the
+same account datasets, letting a custom dashboard query the account
 without going through entities.
 
 ---


### PR DESCRIPTION
The architecture doc's WebSocket API section (§10) still listed `view`, which was removed in #29, and labelled `castdevices` as `cast_devices`. Corrects the endpoint list to match what's actually registered.

The `/views/` mentions in the history section (§13) are the deprecated **Spotify** browse API and are left as-is.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)