### PR TITLE
Fix two debug logs missing their format argument

### DIFF
--- a/custom_components/spotcast/cast.py
+++ b/custom_components/spotcast/cast.py
@@ -61,7 +61,7 @@ async def async_play_media(
 ) -> bool:
     """Play Media"""
     if media_id is None or not media_id.startswith("spotify:"):
-        LOGGER.debug("`%s` is not a valid spotify media id")
+        LOGGER.debug("`%s` is not a valid spotify media id", media_id)
         return False
 
     LOGGER.debug(

--- a/custom_components/spotcast/spotify/account/library.py
+++ b/custom_components/spotcast/spotify/account/library.py
@@ -186,7 +186,7 @@ class LibraryMixin:
     async def async_get_episode(self, uri: str) -> str:
         """Retrieves the information of a podcast episode"""
         await self.async_ensure_tokens_valid()
-        LOGGER.debug("Fetching information from episode `%s`")
+        LOGGER.debug("Fetching information from episode `%s`", uri)
 
         result = await self.hass.async_add_executor_job(
             self.apis["public"].episode,


### PR DESCRIPTION
## What

Two `LOGGER.debug` calls used a `%s` placeholder but passed no value, so they logged a literal `` `%s` `` instead of the intended data (pylint `E1206` logging-too-few-args flags both):

- `cast.py` — the "is not a valid spotify media id" line dropped `media_id`
- `spotify/account/library.py` (`async_get_episode`) — the "Fetching information from episode" line dropped `uri`

Both are debug-level and harmless at runtime, but they make the log useless for the exact case they exist to diagnose. Found while live-testing all spotcast services against a real Home Assistant instance.

## Verification

- Full unittest suite green (669 tests).
- `pylint --enable=logging-too-few-args` clean (both `E1206` gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)