### PR TITLE
Release v6.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.2.0
+current_version = 6.3.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[^\d]*)(?P<build>\d+))?
 serialize = 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import DEFAULT_OPTIONS
 from .spotify import SpotifyAccount
 from .coordinator import SpotcastCoordinator
 
-__version__ = "6.2.0"
+__version__ = "6.3.0"
 
 
 LOGGER = getLogger(__name__)

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -22,5 +22,5 @@
         "spotipy>=2.26.0",
         "RapidFuzz>=3.14.5"
     ],
-    "version": "6.2.0"
+    "version": "6.3.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotcast"
-version = "6.2.0"
+version = "6.3.0"
 description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for Chromecast as well as Spotify Connect devices."
 readme = "README.md"
 requires-python = ">=3.14.2"


### PR DESCRIPTION
Version bump 6.2.0 -> 6.3.0.

### Added
- **Current-playlist sensor**: a new `Spotify Current Playlist` sensor exposes the human-readable name of whatever playlist is playing, resolved through Spotify's internal metadata endpoint so it also works for editorial and algorithmic playlists ([fondberg/spotcast#569](https://github.com/fondberg/spotcast/issues/569)).

### Fixed
- Two `LOGGER.debug` calls logged a literal `%s` instead of the media id / episode uri they were meant to report (#33).

### Changed
- Removed the dead `spotcast/view` WebSocket endpoint (Spotify deprecated the underlying `/views/` API in November 2024, so it returned nothing) (#29).
- Split the 1319-line `SpotifyAccount` class into a package of focused mixins behind an unchanged public API; no behavior change (#32).
- Added an integration architecture document under `docs/` and refreshed the README for users migrating from the original project (#26, #28, #30, #31).

All 9 spotcast services were live-tested against a real Home Assistant instance for this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)