### PR TITLE
Stop running CI twice on release branches

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - release/*
     paths-ignore:
       - docs/*
       - "*.md"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - main
-      - release/**
   pull_request:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   hacs:

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -5,13 +5,16 @@ on:
   push:
     branches:
       - main
-      - release/*
     paths-ignore:
       - docs/*
       - "*.md"
   pull_request:
   schedule:
     - cron: "0 0 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - release/*
     paths-ignore:
       - docs/*
       - "*.md"

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - release/*
     paths-ignore:
       - docs/*
       - "*.md"


### PR DESCRIPTION
## Problem

Every check ran **twice** on release PRs (and a third time on merge). The workflows trigger on both:

```yaml
on:
  push:
    branches: [ main, 'release/*' ]   # release/6.3.0 matches this
  pull_request:                        # ...and it also has a PR
```

A `release/*` branch with an open PR matches **both** events, so the checks run on effectively the same commit twice. Feature branches (`fix/...`, `refactor/...`) were unaffected because their names don't match the push filter — which is why only release PRs showed doubles.

The existing `concurrency` groups can't fix this: `push` and `pull_request` carry different `github.ref` values (`refs/heads/release/6.3.0` vs `refs/pull/N/merge`), so they land in different concurrency groups and never cancel each other.

## Change

- Remove `release/*` / `release/**` from the `push:` filters in all five workflows. Release branches always go through a PR, so the `pull_request` run already covers them. `main` stays in the filter so the post-merge run still gates the protected branch — which matters because releases are admin-merged and can bypass the up-to-date check.
- Add the same `concurrency` block to `hassfest` and `hacs`, which lacked one, so rapid re-pushes cancel superseded runs like the other three already do.

Net effect: a release PR now runs each check once (PR) plus once post-merge (main), instead of three times. This PR's own branch doesn't match the push filter, so its checks run once — demonstrating the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)