### PR TITLE
Correct inaccurate service and websocket documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Spotcast creates multiple entities for each Spotify account.
 | `sensor.[...]_spotify_followers`    | Tracks the number of followers the account has.                                        | `int`           |
 | `sensor.[...]_spotify_liked_songs`  | Tracks the number of songs liked by the account.                                       | `int`           |
 | `sensor.[...]_spotify_playlists`    | Tracks the number of playlists created by the account.                                 | `int`           |
+| `sensor.[...]_spotify_current_playlist` | Reports the name of the playlist currently playing, resolved through Spotify's internal endpoint so it also works for editorial playlists. | `str\|unknown`  |
 | `sensor.[...]_spotify_account_type` | Diagnostic sensor that reports the type of account connected through Spotcast.         | `user`          |
 | `sensor.[...]_spotify_product`      | Diagnostic sensor that reports the subscription level of the account.                  | `premium\|free` |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ Config entry (per Spotify account)
   data.desktop_api    -> desktop OAuth token   (elevated capabilities)
         |
         v
-  SpotifyAccount  (spotify/account.py)
+  SpotifyAccount  (spotify/account/ package: facade __init__.py + mixins)
     sessions["public"]  = PublicSession   -> api.spotify.com  (spotipy)
     sessions["private"] = DesktopSession  -> accounts.spotify.com + spclient
         |

--- a/docs/services/add_to_queue.md
+++ b/docs/services/add_to_queue.md
@@ -1,6 +1,6 @@
 # Add To Queue
 
-Adds a list of spotify URI to the 
+Adds a list of Spotify URIs to the account's playback queue.
 
 ## Action
 
@@ -10,14 +10,14 @@ data:
     spotify_uris:
         - spotify:track:03Vh87Tg6boENhCNstwKX2
         - spotify:track:2GfQhXyoUXYTkMHDXJhCU5
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
 ```
 
 ###  `spotify_uris` (list[str])
 
 A list of spotify URI or URL to add to the queue of the current playback
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 

--- a/docs/services/play_custom_context.md
+++ b/docs/services/play_custom_context.md
@@ -9,11 +9,11 @@ action: spotcast.play_custom_context
 data:
     media_player:
         entity_id: media_player.foo
-    items:
+    tracks:
         - spotify:track:2GfQhXyoUXYTkMHDXJhCU5
         - spotify:track:6z7lKrdW3hwtv9hXH5YK3l
         - spotify:track:55mJleti2WfWEFNFcBduhc
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
     data:
         repeat: context
 ```
@@ -22,11 +22,11 @@ data:
 
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
-### `items` (list[str])
+### `tracks` (list[str])
 
 A list of Spotify URI or URL used to build a custom context for playback. The list of songs will be used as if it was an album or playlist. Songs added to queue still take precedent on next item in context.
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 

--- a/docs/services/play_dj.md
+++ b/docs/services/play_dj.md
@@ -9,7 +9,7 @@ action: spotcast.play_dj
 data:
     media_player:
         entity_id: media_player.foo
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
     data:
         repeat: context
 ```
@@ -18,7 +18,7 @@ data:
 
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 

--- a/docs/services/play_from_search.md
+++ b/docs/services/play_from_search.md
@@ -16,7 +16,7 @@ data:
         artist: The Drones
         album: Feelin Kinda Free
         year: 2010-2019
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
     data:
         repeat: context
 ```
@@ -54,7 +54,7 @@ A list of filters to apply to the search result. Are key value pairs of filters 
 - `isrc`: The Iternational Standard Recording Code of the song searched for. Can only be used on songs.
 - `genre`: The genre of the item searched for. can only be used on artist or tracks
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 
@@ -73,4 +73,4 @@ Set of additional settings to apply when starting the playback. The available op
 | `volume`   | `int`, `range 0-100`      | `null`  | The percentage (as an integer of the percentage value) to start plaback at. Volume is kept unchanged if `null`                              |
 | `repeat`   | `track \| context \| off` | `null`  | The repeat mode is kept the same if `null`                                                                                                  |
 | `shuffle`  | `bool`                    | `null`  | Sets the playback to shuffle if `True`. Is kept unchanged if `null`.                                                                        |
-| `limit`    | `positive_int`            | `20`    | Sets the maximum number of items to retrieve when looking for a track. Forced to 1 for other item types                                     |
+| `limit`    | `positive_int`            | `1`     | Maximum number of items to retrieve per item type from the search. The first result is the one played                                       |

--- a/docs/services/play_liked_songs.md
+++ b/docs/services/play_liked_songs.md
@@ -9,7 +9,7 @@ action: spotcast.play_liked_songs
 data:
     media_player:
         entity_id: media_player.foo
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
     data:
         repeat: context
 ```
@@ -18,7 +18,7 @@ data:
 
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 

--- a/docs/services/play_media.md
+++ b/docs/services/play_media.md
@@ -10,7 +10,7 @@ data:
     media_player:
         entity_id: media_player.foo
     spotify_uri: spotify:album:1chw1DFmefTueG1VbNVoGN
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
     data:
         repeat: context
 ```
@@ -19,11 +19,13 @@ data:
 
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
-### `uri` (str)
+### `spotify_uri` (str)
+
+*Required*
 
 The Spotify URI or URL used for the context in the playback. In the case of a track URI, the context will become the album of the track, but set to the correct position of the track in the album. This behavior can be changed with the `track_context` option in `data`: `track` plays only the song, `album` (default) plays the rest of the album afterwards, and an album or playlist URI (e.g. `spotify:playlist:xxxx`) plays the track inside that context, continuing with the context afterwards. The track must be part of the provided context.
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 
@@ -45,4 +47,4 @@ Set of additional settings to apply when starting the playback. The available op
 | `random`   | `bool`                    | `False` | Sets the context playback to a random song of the context. Only available for albums, playlists and custom contexts |
 
 > [!NOTE]
-> **Spotify editorial/algorithmic playlists** (the `spotify:playlist:37i9…` IDs - Daily Mix, Discover Weekly, Release Radar, song radios, etc.): Spotify no longer serves these playlists' contents through the Web API, so `random` cannot read the real track count. For them it falls back to a random start within the **first 25 tracks** (emitted as a log warning). Regular playlists are unaffected.
+> **Spotify editorial/algorithmic playlists** (the `spotify:playlist:37i9…` IDs - Daily Mix, Discover Weekly, Release Radar, song radios, etc.): Spotify no longer serves these playlists' contents through the public Web API, so `random` cannot read the track count from there. For them it resolves the real track count through Spotify's internal metadata endpoint and picks a random start across the **whole playlist**. Only if that endpoint is unavailable does it fall back to a random start within the first 25 tracks (emitted as a log warning). Regular playlists are unaffected.

--- a/docs/services/play_saved_episodes.md
+++ b/docs/services/play_saved_episodes.md
@@ -9,7 +9,7 @@ action: spotcast.play_saved_episodes
 data:
     media_player:
         entity_id: media_player.foo
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
     data:
         repeat: context
 ```
@@ -18,7 +18,7 @@ data:
 
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 

--- a/docs/services/transfer_playback.md
+++ b/docs/services/transfer_playback.md
@@ -9,16 +9,18 @@ action: spotcast.transfer_playback
 data:
     media_player:
         entity_id: media_player.foo
-    spotify_account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
     data:
         repeat: context
 ```
 
 ### `media_player` (dict)
 
+*Required*
+
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
-### `spotify_account` (str)
+### `account` (str)
 
 *Optional*
 
@@ -39,4 +41,4 @@ Set of additional settings to apply when starting the playback. The available op
 | `shuffle`  | `bool`                    | `null`  | Sets the playback to shuffle if `True`. Is kept unchanged if `null`.                                                                        |
 
 > [!NOTE]
-> **Spotify editorial/algorithmic playlists** (the `spotify:playlist:37i9…` IDs): Spotify no longer serves these playlists' contents through the Web API, so the exact current track can't be located when rebuilding playback - it restarts from the **first track** of the context.
+> **Spotify editorial/algorithmic playlists** (the `spotify:playlist:37i9…` IDs): when rebuilding playback, the currently playing track's URI is passed directly as the offset, so playback resumes at that track without paginating through the whole context.

--- a/docs/websocket/accounts.md
+++ b/docs/websocket/accounts.md
@@ -7,17 +7,17 @@ Provides a list of Spotify Accounts currently managed by Spotcast.
 ```json
 {
     "id": 3,
-    "type": "spotcast/castdevices"
+    "type": "spotcast/accounts"
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/castdevices`
+The endpoint of the websocket to reach. Must be `spotcast/accounts`
 
 ## Response
 
@@ -48,7 +48,7 @@ The endpoint of the websocket to reach. Must be `spotcast/castdevices`
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id provided in the request
 

--- a/docs/websocket/cast_devices.md
+++ b/docs/websocket/cast_devices.md
@@ -11,7 +11,7 @@ Provides a list of Chromecast Devices available in Home Assistant.
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id of the transaction. Must be an increment of the last transaction id.
 
@@ -49,7 +49,7 @@ The endpoint of the websocket to reach. Must be `spotcast/castdevices`
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id provided in the request
 

--- a/docs/websocket/categories.md
+++ b/docs/websocket/categories.md
@@ -9,11 +9,11 @@ Provides the list of Browse Categories available for an account.
     "id": 4,
     "type": "spotcast/categories",
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
-    "limit": 10,
+    "limit": 10
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id of the transaction. Must be an increment of the last transaction id.
 
@@ -66,7 +66,7 @@ Limits the number of categories retrieved to the number provided. If absent, ret
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id provided in the request
 

--- a/docs/websocket/devices.md
+++ b/docs/websocket/devices.md
@@ -12,13 +12,13 @@ Provides the list of currently available player for a Spotify Account
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/categories`
+The endpoint of the websocket to reach. Must be `spotcast/devices`
 
 ### `account` (str)
 
@@ -52,7 +52,7 @@ The entry id of the account used to look for available devices. Defaulst to the 
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id provided in the request
 
@@ -70,7 +70,7 @@ The result of the transaction
 
 > #### `total` (int)
 > 
-> Number of browse categories retrieved
+> Number of devices available for the account
 > 
 > #### `devices` (list[dict])
 > 

--- a/docs/websocket/player.md
+++ b/docs/websocket/player.md
@@ -12,13 +12,13 @@ Provides the active playback state for a Spotify Account
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/categories`
+The endpoint of the websocket to reach. Must be `spotcast/player`
 
 ### `account` (str)
 
@@ -146,7 +146,7 @@ The entry id of the account used to get the active playback state. Defaults to t
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id provided in the request
 

--- a/docs/websocket/playlists.md
+++ b/docs/websocket/playlists.md
@@ -13,7 +13,7 @@ Provides the list of the user's playlists
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id of the transaction. Must be an increment of the last transaction id.
 
@@ -51,7 +51,7 @@ Sets a limit to the number of playlists to retrieve
 }
 ```
 
-### `id` (str)
+### `id` (int)
 
 The id provided in the request
 


### PR DESCRIPTION
Docs-only. A full cross-check of every page under `docs/` against the actual code (service schemas, websocket handlers, entity registrations) turned up a lot of drifted or copy-pasted detail.

## Service docs
- **`spotify_account` → `account`** in every service page. The schemas reject unknown keys, so the old examples would fail validation.
- **play_media**: field is `spotify_uri` (required), not `uri`. The editorial-playlist `random` note was stale — it now describes the current behaviour (resolve the real track count via Spotify's internal endpoint and randomise across the whole playlist; the first-25 window is only the fallback when that endpoint is unavailable).
- **play_custom_context**: the list field is `tracks`, not `items`.
- **play_from_search**: `limit` default is `1`, not `20`.
- **transfer_playback**: `media_player` is required; the editorial-playlist note now reflects that playback resumes at the current track's URI (per #582) rather than "the first track".
- **add_to_queue**: completed a description that was cut off mid-sentence.

## WebSocket docs
- **accounts**: the request example showed `spotcast/castdevices` — corrected to `spotcast/accounts`.
- **devices / player**: prose said `spotcast/categories` — corrected. `devices` `total` was described as "browse categories".
- **`id` type**: the request/transaction `id` is an int (`cv.positive_int`), not a string — fixed on the six pages that had it wrong. The nested Spotify object `id` fields (playlist/track/device/category IDs) correctly stay `str`.
- **categories**: removed a trailing comma that made the JSON example invalid.

## Other
- **README**: added the missing "current playlist" sensor row (there are 8 sensors, the table listed 7).
- **architecture**: `account.py` is now the `spotify/account/` package.

Found via a parallel review of all pages against the code; each change was verified against the corresponding schema/handler/registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)