### PR TITLE
Remove dead code and fix stale in-code docs

### DIFF
--- a/custom_components/spotcast/media_player/exceptions.py
+++ b/custom_components/spotcast/media_player/exceptions.py
@@ -3,8 +3,8 @@
 Classes:
     - MediaPlayerError
     - MediaPlayerNotFoundError
-    - InvalidPlatformError
-    - MissingDeviceTypeError
+    - UnknownIntegrationError
+    - MissingActiveDeviceError
 """
 
 from homeassistant.exceptions import HomeAssistantError
@@ -16,14 +16,6 @@ class MediaPlayerError(HomeAssistantError):
 
 class MediaPlayerNotFoundError(MediaPlayerError):
     """Error raised when the player could not be found"""
-
-
-class InvalidPlatformError(MediaPlayerError):
-    """Raised when the platform provided is invalid"""
-
-
-class MissingDeviceTypeError(MediaPlayerError):
-    """Raised when the device type os not set for the media player"""
 
 
 class UnknownIntegrationError(MediaPlayerError):

--- a/custom_components/spotcast/services/play_from_search.py
+++ b/custom_components/spotcast/services/play_from_search.py
@@ -78,8 +78,8 @@ async def async_play_from_search(hass: HomeAssistant, call: ServiceCall):
     account_id = call.data.get("account")
     extras = call.data.get("data", {})
 
-    # sets the limit according to item type or extras limit. Defaults
-    # to 20
+    # Number of items to retrieve per item type. Defaults to 1 so the
+    # first match is played.
     limit = extras.get("limit", 1)
 
     # get account

--- a/custom_components/spotcast/spotify/account/__init__.py
+++ b/custom_components/spotcast/spotify/account/__init__.py
@@ -81,7 +81,7 @@ class SpotifyAccount(  # pylint: disable=too-many-instance-attributes
         - sessions(dict[str, ConnectionSession]): A dictionary with
             both the Internal (Private) and External (Public) API
             access
-        - is_defaults(bool): set to True if the account should be
+        - is_default(bool): set to True if the account should be
             treated as default when calling services
 
     Properties:
@@ -94,6 +94,8 @@ class SpotifyAccount(  # pylint: disable=too-many-instance-attributes
         - product(str): the current subscription product the user has
         - type(str): the type of account loaded
         - liked_songs_uri(str): the uri for the liked_songs playlist
+        - device_info(DeviceInfo): the Home Assistant device info
+        - base_refresh_rate(int): the base dataset refresh rate
 
     Constants:
         - SCOPE(tuple): A list of API permissions required for the
@@ -101,8 +103,10 @@ class SpotifyAccount(  # pylint: disable=too-many-instance-attributes
         - DJ_URI(str): the uri for the DJ playlist
         - REFRESH_RATE(int): default rate at which to deem the cache
             deprecated
-       - DATASETS(dict[str, dict]): Default configuration for datasets
+        - DATASETS(dict[str, dict]): Default configuration for datasets
             used by the account
+        - SESSION_CONFIG_MAP(dict[str, str]): maps each session key to
+            its config entry data key
 
     Functions:
         - async_from_config_entry

--- a/custom_components/spotcast/spotify/account/paging.py
+++ b/custom_components/spotcast/spotify/account/paging.py
@@ -24,7 +24,6 @@ class PagingMixin:  # pylint: disable=too-few-public-methods
         prepends: list = None,
         appends: list = None,
         sub_layer: str = None,
-        max_items: int = None,
     ) -> int:
         """Returns the number of item in a specific pagination
 

--- a/custom_components/spotcast/spotify/account/profile.py
+++ b/custom_components/spotcast/spotify/account/profile.py
@@ -82,10 +82,6 @@ class ProfileMixin:
         Args:
             attribute(str): the attribute to fetch from the profile
 
-        Raises:
-            ProfileNotLoadedError: Raised if the profile hasn't been
-                loaded yet.
-
         Returns:
             Any: the value at the key in the profile
         """

--- a/custom_components/spotcast/spotify/account/token.py
+++ b/custom_components/spotcast/spotify/account/token.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import datetime as dt
 from logging import getLogger
 
-from homeassistant.config_entries import ConfigEntry, SOURCE_REAUTH
+from homeassistant.config_entries import SOURCE_REAUTH
 
 from custom_components.spotcast.sessions import ConnectionSession
 from custom_components.spotcast.spotify.exceptions import TokenError
@@ -34,8 +34,8 @@ class TokenMixin:
         """Retrives a token from the requested session.
 
         Args:
-            api(str): The api to retrieve from. Cann be `internal`
-                or `external`.
+            api(str): The session to retrieve from. Can be `public`
+                or `private`.
 
         Returns:
             str: token for the requested session
@@ -48,8 +48,8 @@ class TokenMixin:
         """Retrives a token from the requested session.
 
         Args:
-            api(str): The api to retrieve from. Can be `internal` or
-                `external`.
+            api(str): The session to retrieve from. Can be `public` or
+                `private`.
 
         Returns:
             - str: token for the requested session
@@ -135,10 +135,3 @@ class TokenMixin:
                 )
 
             raise exc
-
-    def _request_reauth(self, entry: ConfigEntry):
-        """Requests reauth for an entry."""
-        entry.async_start_reauth(
-            self.hass,
-            context={"source": SOURCE_REAUTH},
-        )

--- a/custom_components/spotcast/spotify/exceptions.py
+++ b/custom_components/spotcast/spotify/exceptions.py
@@ -2,36 +2,17 @@
 
 Classes:
     - TokenError
-    - ExpiredCookiesError
-    - UnknownTokenError
-    - InvalidCookiesError
-    - NoAuthManagerError
-    - ProfileNotLoadedError
+    - PlaybackError
+    - ExpiredDatasetError
+    - SearchQueryError
+    - InvalidFilterError
+    - InvalidTagsError
+    - InvalidItemTypeError
 """
 
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from custom_components.spotcast.exceptions import TokenError
-
-
-class ExpiredCookiesError(TokenError):
-    """Raised when valid cookies are expired"""
-
-
-class UnknownTokenError(TokenError):
-    """Raised when an error occurs while getting a spotify Token"""
-
-
-class InvalidCookiesError(TokenError):
-    """Raised in the case of invalid cookies provided"""
-
-
-class NoAuthManagerError(TokenError):
-    """The Spotify Account has no Authentication manager in place"""
-
-
-class ProfileNotLoadedError(HomeAssistantError):
-    """Raised when the profile is not yet loaded"""
 
 
 class PlaybackError(HomeAssistantError):
@@ -56,7 +37,3 @@ class InvalidTagsError(SearchQueryError):
 
 class InvalidItemTypeError(SearchQueryError):
     """Raised when a search query is built with an invalid item type"""
-
-
-class InvalidUriError(ServiceValidationError):
-    """raised when an invalid uri is provided"""

--- a/custom_components/spotcast/websocket/playlists_handler.py
+++ b/custom_components/spotcast/websocket/playlists_handler.py
@@ -14,7 +14,6 @@ ENDPOINT = "spotcast/playlists"
 SCHEMA = vol.Schema({
     vol.Required("id"): cv.positive_int,
     vol.Required("type"): ENDPOINT,
-    vol.Optional("category"): cv.string,
     vol.Optional("account"): cv.string,
     vol.Optional("limit"): cv.positive_int,
 })


### PR DESCRIPTION
Cleanup found during a full sweep of `custom_components/`. No behaviour change; full test suite stays green (669) and pylint holds (9.68).

## Dead code removed
- **Eight unused exception classes**, leftovers from the removed cookie/desktop auth path and unused validation branches: `ExpiredCookiesError`, `UnknownTokenError`, `InvalidCookiesError`, `NoAuthManagerError`, `ProfileNotLoadedError`, `InvalidUriError` (`spotify/exceptions.py`), and `InvalidPlatformError`, `MissingDeviceTypeError` (`media_player/exceptions.py`). None were imported, raised, or caught anywhere in `custom_components/` or `test/`.
- **`TokenMixin._request_reauth`** — never called; the reauth is done inline in `_async_refresh_single_token`. Also dropped the now-unused `ConfigEntry` import.
- The vestigial **`category`** request field on the playlists websocket schema — the handler never read it and always returns `"user"`.
- The unused **`max_items`** parameter on `PagingMixin._async_get_count`.

## Stale in-code docs fixed
- Both exceptions module docstrings listed removed classes and omitted the live ones.
- `get_profile_value` claimed it raises `ProfileNotLoadedError`; it never does.
- `get_token`/`async_get_token` described the argument as `internal`/`external`; the real session keys are `public`/`private`.
- `play_from_search`: a comment said "Defaults to 20" but the default is `1`.
- `SpotifyAccount` docstring: `is_defaults` → `is_default`, plus the missing `device_info`/`base_refresh_rate` properties and `SESSION_CONFIG_MAP` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)