### PR TITLE
Allow a playlist/album URI as track_context

### DIFF
--- a/custom_components/spotcast/services/utils.py
+++ b/custom_components/spotcast/services/utils.py
@@ -20,6 +20,33 @@ from custom_components.spotcast.services.exceptions import (
     DeviceNotFoundError,
 )
 
+
+def track_context(value: str) -> str:
+    """Validates the `track_context` play option.
+
+    Accepts `track` (play only the song), `album` (play the song's
+    album), or an album or playlist Spotify URI to play the track inside
+    that specific context.
+
+    Raises:
+        - vol.Invalid: when the value is neither keyword nor a supported
+            album/playlist URI.
+    """
+    if value in ("track", "album"):
+        return value
+
+    if isinstance(value, str) and (
+        value.startswith("spotify:album:")
+        or value.startswith("spotify:playlist:")
+    ):
+        return value
+
+    raise vol.Invalid(
+        "track_context must be 'track', 'album', or a Spotify album or "
+        "playlist URI"
+    )
+
+
 EXTRAS_SCHEMA = vol.Schema({
     vol.Optional("position"): cv.positive_float,
     vol.Optional("offset"): cv.positive_int,
@@ -31,7 +58,7 @@ EXTRAS_SCHEMA = vol.Schema({
     vol.Optional("shuffle"): cv.boolean,
     vol.Optional("limit"): cv.positive_int,
     vol.Optional("random"): cv.boolean,
-    vol.Optional("track_context"): vol.In(["track", "album"]),
+    vol.Optional("track_context"): track_context,
 })
 
 

--- a/test/services/utils/test_track_context.py
+++ b/test/services/utils/test_track_context.py
@@ -1,0 +1,54 @@
+"""Module to test the track_context validator and EXTRAS_SCHEMA"""
+
+from unittest import TestCase
+
+import voluptuous as vol
+
+from custom_components.spotcast.services.utils import (
+    track_context,
+    EXTRAS_SCHEMA,
+)
+
+
+class TestAcceptedValues(TestCase):
+
+    def test_keyword_track(self):
+        self.assertEqual(track_context("track"), "track")
+
+    def test_keyword_album(self):
+        self.assertEqual(track_context("album"), "album")
+
+    def test_album_uri(self):
+        uri = "spotify:album:1chw1DFmefTueG1VbNVoGN"
+        self.assertEqual(track_context(uri), uri)
+
+    def test_playlist_uri(self):
+        uri = "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"
+        self.assertEqual(track_context(uri), uri)
+
+
+class TestRejectedValues(TestCase):
+
+    def test_unknown_keyword_rejected(self):
+        with self.assertRaises(vol.Invalid):
+            track_context("artist")
+
+    def test_unsupported_uri_type_rejected(self):
+        with self.assertRaises(vol.Invalid):
+            track_context("spotify:artist:0OdUWJ0sBjDrqHygGUXeCF")
+
+    def test_garbage_rejected(self):
+        with self.assertRaises(vol.Invalid):
+            track_context("not a context")
+
+
+class TestThroughExtrasSchema(TestCase):
+
+    def test_playlist_uri_passes_extras_schema(self):
+        uri = "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M"
+        result = EXTRAS_SCHEMA({"track_context": uri})
+        self.assertEqual(result["track_context"], uri)
+
+    def test_invalid_track_context_fails_extras_schema(self):
+        with self.assertRaises(vol.Invalid):
+            EXTRAS_SCHEMA({"track_context": "spotify:artist:foo"})


### PR DESCRIPTION
## The bug

`play_media` documents — and implements, via `async_context_index` — a `track_context` that accepts an album or playlist URI: play a track *inside that specific context*, continuing with it afterwards. But `EXTRAS_SCHEMA` restricted `track_context` to `vol.In(["track", "album"])`, so any URI value was rejected at validation before ever reaching that code. The feature was effectively dead, and the documented example failed with `value must be one of ['album', 'track']`.

## The fix

Replace the strict enum with a validator that accepts `track`, `album`, or a `spotify:album:` / `spotify:playlist:` URI — matching exactly what `async_context_index` already handles.

## Validation

- **9 new unit tests** for the validator and through `EXTRAS_SCHEMA` (accepts the two keywords + album/playlist URIs; rejects unknown keywords and unsupported URI types). `async_context_index`'s index computation was already unit-tested for album/playlist/invalid contexts.
- **Live-tested against a real Home Assistant instance**: the released build rejects a URI `track_context` (reproducing the bug exactly), and the underlying context+offset playback this feature drives resolves to the correct track within the context (played playlist "Sport 1" at the computed offset and got the expected track, in the playlist context).

Full suite: 678 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)