### PR TITLE
Release v6.4.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.3.0
+current_version = 6.4.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[^\d]*)(?P<build>\d+))?
 serialize = 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import DEFAULT_OPTIONS
 from .spotify import SpotifyAccount
 from .coordinator import SpotcastCoordinator
 
-__version__ = "6.3.0"
+__version__ = "6.4.0"
 
 
 LOGGER = getLogger(__name__)

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -22,5 +22,5 @@
         "spotipy>=2.26.0",
         "RapidFuzz>=3.14.5"
     ],
-    "version": "6.3.0"
+    "version": "6.4.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotcast"
-version = "6.3.0"
+version = "6.4.0"
 description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for Chromecast as well as Spotify Connect devices."
 readme = "README.md"
 requires-python = ">=3.14.2"


### PR DESCRIPTION
Version bump 6.3.0 -> 6.4.0.

### Fixed
- `play_media`'s `track_context` now accepts an album or playlist URI, so you can start a track inside a specific context and keep playing it afterwards. This was documented and implemented but blocked by a too-strict validation schema (#39).

### Changed
- Removed dead code (eight unused exception classes, an unused reauth method, a vestigial websocket schema field) and corrected stale in-code docstrings (#38).

### Documentation
- Corrected numerous inaccuracies across the service and websocket docs: the account field is `account` (not `spotify_account`), `play_media` uses `spotify_uri`, `play_custom_context` uses `tracks`, the editorial-playlist `random` behaviour, websocket endpoint names and `id` types, a missing sensor row, and more (#37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)