### PR TITLE
Mark every service field required or optional consistently

### DIFF
--- a/docs/services/add_to_queue.md
+++ b/docs/services/add_to_queue.md
@@ -13,7 +13,9 @@ data:
     account: 01JDG07KSBTYWZGJSBJ1EW6XEF
 ```
 
-###  `spotify_uris` (list[str])
+### `spotify_uris` (list[str])
+
+*Required*
 
 A list of spotify URI or URL to add to the queue of the current playback
 

--- a/docs/services/like_media.md
+++ b/docs/services/like_media.md
@@ -14,6 +14,8 @@ data:
 ```
 ### `spotify_uris` (list[str])
 
+*Required*
+
 A list of Spotify URIs or URLs to be liked. These can represent various types of content, including tracks, albums, or playlists.
 
 ### `account` (str)

--- a/docs/services/play_custom_context.md
+++ b/docs/services/play_custom_context.md
@@ -20,9 +20,13 @@ data:
 
 ### `media_player` (dict)
 
+*Optional*
+
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
 ### `tracks` (list[str])
+
+*Required*
 
 A list of Spotify URI or URL used to build a custom context for playback. The list of songs will be used as if it was an album or playlist. Songs added to queue still take precedent on next item in context.
 

--- a/docs/services/play_dj.md
+++ b/docs/services/play_dj.md
@@ -16,6 +16,8 @@ data:
 
 ### `media_player` (dict)
 
+*Optional*
+
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
 ### `account` (str)

--- a/docs/services/play_from_search.md
+++ b/docs/services/play_from_search.md
@@ -23,19 +23,25 @@ data:
 
 ### `media_player` (dict)
 
+*Optional*
+
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
 ### `search_term` (str)
 
+*Required*
+
 A generic search term that could be for any type of items
 
-### item_types (list[str])
+### `item_types` (list[str])
+
+*Required*
 
 A list of item types to look for in the search query.
 
 ### `tags` (list[str])
 
-*optional*
+*Optional*
 
 A list of tags used to limit the search. Can only be used to search for albums:
 
@@ -43,6 +49,8 @@ A list of tags used to limit the search. Can only be used to search for albums:
 - `new`: Limits results to albums released in the past 2 weeks
 
 ### `filters` (dict[str,str])
+
+*Optional*
 
 A list of filters to apply to the search result. Are key value pairs of filters that can be:
 

--- a/docs/services/play_liked_songs.md
+++ b/docs/services/play_liked_songs.md
@@ -16,6 +16,8 @@ data:
 
 ### `media_player` (dict)
 
+*Optional*
+
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
 ### `account` (str)

--- a/docs/services/play_media.md
+++ b/docs/services/play_media.md
@@ -17,6 +17,8 @@ data:
 
 ### `media_player` (dict)
 
+*Optional*
+
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
 ### `spotify_uri` (str)

--- a/docs/services/play_saved_episodes.md
+++ b/docs/services/play_saved_episodes.md
@@ -16,6 +16,8 @@ data:
 
 ### `media_player` (dict)
 
+*Optional*
+
 Let the user select a compatible device on which to start the playback. **_Must be a single device_**.
 
 ### `account` (str)


### PR DESCRIPTION
Follow-up to the docs accuracy pass. The service docs marked `account`/`data` as *Optional* and a couple of required fields, but left most field headings (notably `media_player` and the required list/term fields) with **no required/optional marker**, so a reader couldn't tell which inputs are mandatory.

## Markers added (matching `services.yaml`)
- `media_player` → *Optional* on all play services (stays *Required* on `transfer_playback`, where the schema requires it)
- `spotify_uris` (add_to_queue, like_media), `tracks` (play_custom_context), `search_term` and `item_types` (play_from_search) → *Required*
- `tags`, `filters` (play_from_search) → *Optional*

## Formatting glitches fixed alongside
- `add_to_queue`: `###  ` heading had a double space
- `play_from_search`: `### item_types` was missing its backticks
- `play_from_search`: `tags` used a lowercase `*optional*`

Every service field now carries a consistent marker. The websocket docs use a different but internally-consistent convention (only optional fields are marked), so they're left as-is.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)