### PR TITLE
Rebuild the websocket docs to one consistent structure

### DIFF
--- a/docs/websocket/accounts.md
+++ b/docs/websocket/accounts.md
@@ -1,47 +1,51 @@
 # Accounts
 
-Provides a list of Spotify Accounts currently managed by Spotcast.
+Provides the list of Spotify accounts currently managed by Spotcast.
 
 ## Request
 
 ```json
 {
-    "id": 3,
+    "id": 1,
     "type": "spotcast/accounts"
 }
 ```
 
 ### `id` (int)
 
+*Required*
+
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/accounts`
+*Required*
+
+The endpoint of the WebSocket to reach. Must be `spotcast/accounts`.
 
 ## Response
 
 ```json
 {
-    "id":2,
-    "type":"result",
-    "success":true,
+    "id": 1,
+    "type": "result",
+    "success": true,
     "result": {
-        "total":2,
+        "total": 2,
         "accounts": [
             {
-                "entry_id":"01JDG07KSBTYWZGJSBJ1EW6XEF",
-                "spotify_id":"foo",
-                "spotify_name":"Foo",
-                "is_default":true,
-                "country":"CA"
+                "entry_id": "01JDG07KSBTYWZGJSBJ1EW6XEF",
+                "spotify_id": "foo",
+                "spotify_name": "Foo",
+                "is_default": true,
+                "country": "CA"
             },
             {
-                "entry_id":"01JDG0ZMDFEN2GDPVHV55R0X4P",
-                "spotify_id":"bar",
-                "spotify_name":"Bar",
-                "is_default":false,
-                "country":"CA"
+                "entry_id": "01JDG0ZMDFEN2GDPVHV55R0X4P",
+                "spotify_id": "bar",
+                "spotify_name": "Bar",
+                "is_default": false,
+                "country": "CA"
             }
         ]
     }
@@ -50,7 +54,7 @@ The endpoint of the websocket to reach. Must be `spotcast/accounts`
 
 ### `id` (int)
 
-The id provided in the request
+The id provided in the request.
 
 ### `type` (str)
 
@@ -58,36 +62,37 @@ Always `result` on a successful request.
 
 ### `success` (bool)
 
-True if the transaction was successful.
+`true` if the transaction was successful.
 
 ### `result` (dict)
 
-The result of the transaction
+The result of the transaction.
 
 > #### `total` (int)
-> 
-> Total number of accounts currently managed by Spotcast
-> 
+>
+> Total number of accounts currently managed by Spotcast.
+>
 > #### `accounts` (list[dict])
-> 
-> A list of all accounts managed by Spotcast
-> 
+>
+> The list of accounts managed by Spotcast.
+>
 > > ##### `entry_id` (str)
-> > 
-> > The identifier of the configuration entry for the account
-> > 
+> >
+> > The identifier of the configuration entry for the account.
+> >
 > > ##### `spotify_id` (str)
-> > 
-> > The Spotify Identifier of the account
-> > 
+> >
+> > The Spotify identifier of the account.
+> >
 > > ##### `spotify_name` (str)
-> > 
-> > The Display Name for the account in Spotify
+> >
+> > The display name for the account in Spotify.
 > >
 > > ##### `is_default` (bool)
-> > 
-> > `true` if the account is used as the default account for Spotcast services and websocket endpoints
-> > 
+> >
+> > `true` if the account is used as the default for Spotcast services and WebSocket endpoints.
+> >
 > > ##### `country` (str)
-> > 
-> > The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code of the user's country as set in the user's account profile.
+> >
+> > The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code from the account profile.
+> >

--- a/docs/websocket/cast_devices.md
+++ b/docs/websocket/cast_devices.md
@@ -1,49 +1,52 @@
 # Cast Devices
 
-Provides a list of Chromecast Devices available in Home Assistant.
+Provides the list of Chromecast devices available in Home Assistant.
 
 ## Request
 
 ```json
 {
-    "id": 3,
+    "id": 1,
     "type": "spotcast/castdevices"
 }
 ```
 
 ### `id` (int)
 
+*Required*
+
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/castdevices`
+*Required*
+
+The endpoint of the WebSocket to reach. Must be `spotcast/castdevices`.
 
 ## Response
 
 ```json
 {
-    "id":3,
-    "type":"result",
-    "success":true,
+    "id": 1,
+    "type": "result",
+    "success": true,
     "result": {
-        "total":13,
+        "total": 2,
         "devices": [
             {
-                "entity_id":"media_player.reveil",
-                "uuid":"",
-                "model_name":"Lenovo Smart Clock",
-                "friendly_name":"Réveil",
-                "manufacturer":"LENOVO"
+                "entity_id": "media_player.reveil",
+                "uuid": "b4d1c2e0-0000-0000-0000-000000000000",
+                "model_name": "Lenovo Smart Clock",
+                "friendly_name": "Reveil",
+                "manufacturer": "LENOVO"
             },
             {
-                "entity_id":"media_player.cuisine",
-                "uuid":"",
-                "model_name":"Google Home",
-                "friendly_name":"Cuisine",
-                "manufacturer":"Google Inc."
-            },
-            ...
+                "entity_id": "media_player.cuisine",
+                "uuid": "a1b2c3d4-0000-0000-0000-000000000000",
+                "model_name": "Google Home",
+                "friendly_name": "Cuisine",
+                "manufacturer": "Google Inc."
+            }
         ]
     }
 }
@@ -51,7 +54,7 @@ The endpoint of the websocket to reach. Must be `spotcast/castdevices`
 
 ### `id` (int)
 
-The id provided in the request
+The id provided in the request.
 
 ### `type` (str)
 
@@ -59,36 +62,37 @@ Always `result` on a successful request.
 
 ### `success` (bool)
 
-True if the transaction was successful.
+`true` if the transaction was successful.
 
 ### `result` (dict)
 
-The result of the transaction
+The result of the transaction.
 
 > #### `total` (int)
-> 
-> Number of Chromecast Devices Available in Home Assistant
-> 
+>
+> Number of Chromecast devices available in Home Assistant.
+>
 > #### `devices` (list[dict])
-> 
-> A list of Chromecast devices
-> 
+>
+> The list of Chromecast devices.
+>
 > > ##### `entity_id` (str)
-> > 
-> > The entity id of the device in Home Assistant
-> > 
+> >
+> > The entity id of the device in Home Assistant.
+> >
 > > ##### `uuid` (str)
-> > 
-> > The Universal Unique Identifier of the Chromecast device
-> > 
+> >
+> > The universally unique identifier of the Chromecast device.
+> >
 > > ##### `model_name` (str)
-> > 
-> > The model of the Chromecast Device as reported by itself.
-> > 
+> >
+> > The model of the Chromecast device as reported by itself.
+> >
 > > ##### `friendly_name` (str)
-> > 
-> > Name of the device in Google Services
-> > 
+> >
+> > The name of the device in Google services.
+> >
 > > ##### `manufacturer` (str)
-> > 
-> > The manufacturer of the Chromecast Device as reported by itself.
+> >
+> > The manufacturer of the Chromecast device as reported by itself.
+> >

--- a/docs/websocket/categories.md
+++ b/docs/websocket/categories.md
@@ -1,12 +1,12 @@
 # Categories
 
-Provides the list of Browse Categories available for an account.
+Provides the list of Browse categories available for an account.
 
 ## Request
 
 ```json
 {
-    "id": 4,
+    "id": 1,
     "type": "spotcast/categories",
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
     "limit": 10
@@ -15,52 +15,49 @@ Provides the list of Browse Categories available for an account.
 
 ### `id` (int)
 
+*Required*
+
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/categories`
+*Required*
+
+The endpoint of the WebSocket to reach. Must be `spotcast/categories`.
 
 ### `account` (str)
 
 *Optional*
 
-The entry id of the account used to look for Browse Categories. Defaults to the Spotcast default account if not provided.
+The `entry_id` of the account to use. Defaults to the default Spotcast account if not provided.
 
 ### `limit` (int)
 
 *Optional*
 
-Limits the number of categories retrieved to the number provided. If absent, retrives all Browse categories available for the account.
+Limits the number of categories retrieved. Retrieves all available categories if not provided.
 
 ## Response
 
 ```json
 {
-    "id": 4,
+    "id": 1,
     "type": "result",
     "success": true,
-    "result":
-    {
+    "result": {
         "total": 10,
         "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
-        "categories":[
+        "categories": [
             {
-                "id":"0JQ5DAt0tbjZptfcdMSKl3",
-                "icon":"https://t.scdn.co/images/728ed47fc1674feb95f7ac20236eb6d7.jpeg",
-                "name":"Made For You"
+                "id": "0JQ5DAt0tbjZptfcdMSKl3",
+                "icon": "https://t.scdn.co/images/728ed47fc1674feb95f7ac20236eb6d7.jpeg",
+                "name": "Made For You"
             },
             {
-                "id":"0JQ5DAqbMKFNNuveavxU1i",
-                "icon":"https://t.scdn.co/images/728ed47fc1674feb95f7ac20236eb6d7.jpeg",
-                "name":"New Releases"
-            },
-            {
-                "id":"0JQ5DAtOnAEpjOgUKwXyxj",
-                "icon":"https://t.scdn.co/images/728ed47fc1674feb95f7ac20236eb6d7.jpeg",
-                "name":"Discover"
-            },
-            ...
+                "id": "0JQ5DAqbMKFNNuveavxU1i",
+                "icon": "https://t.scdn.co/images/728ed47fc1674feb95f7ac20236eb6d7.jpeg",
+                "name": "New Releases"
+            }
         ]
     }
 }
@@ -68,7 +65,7 @@ Limits the number of categories retrieved to the number provided. If absent, ret
 
 ### `id` (int)
 
-The id provided in the request
+The id provided in the request.
 
 ### `type` (str)
 
@@ -76,32 +73,33 @@ Always `result` on a successful request.
 
 ### `success` (bool)
 
-True if the transaction was successful.
+`true` if the transaction was successful.
 
 ### `result` (dict)
 
-The result of the transaction
+The result of the transaction.
 
 > #### `total` (int)
-> 
-> Number of browse categories retrieved
+>
+> Number of Browse categories retrieved.
 >
 > #### `account` (str)
 >
-> The id of the account used in the query
-> 
+> The id of the account used in the query.
+>
 > #### `categories` (list[dict])
-> 
-> The list of browse categories retrieved
+>
+> The list of Browse categories retrieved.
 >
 > > ##### `id` (str)
-> > 
-> > The identifier of the Browse category
-> > 
+> >
+> > The identifier of the Browse category.
+> >
 > > ##### `icon` (str)
-> > 
-> > URL to the image used for the browse category in Spotify's Apps
-> > 
+> >
+> > URL to the image used for the category in Spotify's apps.
+> >
 > > ##### `name` (str)
-> > 
-> > The name of the Browse Category
+> >
+> > The name of the Browse category.
+> >

--- a/docs/websocket/devices.md
+++ b/docs/websocket/devices.md
@@ -1,12 +1,12 @@
 # Devices
 
-Provides the list of currently available player for a Spotify Account
+Provides the list of currently available Spotify Connect devices for an account.
 
 ## Request
 
 ```json
 {
-    "id": 5,
+    "id": 1,
     "type": "spotcast/devices",
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF"
 }
@@ -14,23 +14,27 @@ Provides the list of currently available player for a Spotify Account
 
 ### `id` (int)
 
+*Required*
+
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/devices`
+*Required*
+
+The endpoint of the WebSocket to reach. Must be `spotcast/devices`.
 
 ### `account` (str)
 
 *Optional*
 
-The entry id of the account used to look for available devices. Defaulst to the default Spotcast account if not provided.
+The `entry_id` of the account to use. Defaults to the default Spotcast account if not provided.
 
 ## Response
 
 ```json
 {
-    "id": 5,
+    "id": 1,
     "type": "result",
     "success": true,
     "result": {
@@ -38,7 +42,7 @@ The entry id of the account used to look for available devices. Defaulst to the 
         "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
         "devices": [
             {
-                "id":"042ee68e1c57247fe3c214f1669e5a4933a9f6b4",
+                "id": "042ee68e1c57247fe3c214f1669e5a4933a9f6b4",
                 "is_active": false,
                 "is_private_session": false,
                 "is_restricted": false,
@@ -54,7 +58,7 @@ The entry id of the account used to look for available devices. Defaulst to the 
 
 ### `id` (int)
 
-The id provided in the request
+The id provided in the request.
 
 ### `type` (str)
 
@@ -62,52 +66,53 @@ Always `result` on a successful request.
 
 ### `success` (bool)
 
-True if the transaction was successful.
+`true` if the transaction was successful.
 
 ### `result` (dict)
 
-The result of the transaction
+The result of the transaction.
 
 > #### `total` (int)
-> 
-> Number of devices available for the account
-> 
-> #### `devices` (list[dict])
-> 
-> The number of player available for the account at the moment of the transaction
+>
+> Number of devices available for the account.
 >
 > #### `account` (str)
-> 
-> The id of the account used in the query
+>
+> The id of the account used in the query.
+>
+> #### `devices` (list[dict])
+>
+> The devices available for the account at the time of the transaction. These are the raw Spotify device objects.
 >
 > > ##### `id` (str)
-> > 
-> > The Spotify ID of the device
-> > 
+> >
+> > The Spotify ID of the device.
+> >
 > > ##### `is_active` (bool)
-> > 
-> > `true` if the device is actively playing media
-> > 
+> >
+> > `true` if the device is actively playing media.
+> >
 > > ##### `is_private_session` (bool)
-> > 
-> > `true` if the device is currently set to a private session
-> > 
+> >
+> > `true` if the device is currently in a private session.
+> >
 > > ##### `is_restricted` (bool)
-> > 
-> > `true` if the device can,t be controlled through API calls (meaning Spotcast) cannot control the device
-> > 
+> >
+> > `true` if the device cannot be controlled through the API (Spotcast cannot control it).
+> >
 > > ##### `name` (str)
-> > 
-> > Name of the device as presented in Spotify's Apps
-> > 
+> >
+> > The name of the device as shown in Spotify's apps.
+> >
 > > ##### `supports_volume` (bool)
-> > 
-> > `true` if the device's volume can be controlled through the API
-> > 
+> >
+> > `true` if the device's volume can be controlled through the API.
+> >
 > > ##### `type` (str)
-> > 
-> > The type of devices the media player is
-> > 
+> >
+> > The type of device.
+> >
 > > ##### `volume_percent` (int)
-> > 
-> > An integer between `0` and `100` representing the percentage the voume is set at.
+> >
+> > An integer between `0` and `100` for the current volume percentage.
+> >

--- a/docs/websocket/liked_media.md
+++ b/docs/websocket/liked_media.md
@@ -1,21 +1,26 @@
 # Liked Media
 
-Provides a list of liked media (tracks) for a user.
+Provides the list of liked media (tracks) for a user.
 
 ## Request
 
 ```json
 {
-    "id": 7,
+    "id": 1,
     "type": "spotcast/liked_media",
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF"
 }
 ```
+
 ### `id` (int)
+
+*Required*
 
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
+
+*Required*
 
 The endpoint of the WebSocket to reach. Must be `spotcast/liked_media`.
 
@@ -23,13 +28,15 @@ The endpoint of the WebSocket to reach. Must be `spotcast/liked_media`.
 
 *Optional*
 
-The `entry_id` of the account to use for Spotcast. If empty, the default Spotcast account is used.
+The `entry_id` of the account to use. Defaults to the default Spotcast account if not provided.
 
 ## Response
+
 ```json
 {
-    "id": 7,
+    "id": 1,
     "type": "result",
+    "success": true,
     "result": {
         "total": 5,
         "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
@@ -38,7 +45,7 @@ The `entry_id` of the account to use for Spotcast. If empty, the default Spotcas
             "spotify:track:6rqhFxbN4uN6t6z2p3xPQK",
             "spotify:track:7gBEnASdyC9XBZf51a0tpn",
             "spotify:track:3nYCh0PbdJ23V2Jp0CzJ8N",
-            "spotify:track:3n3Ppam7vgaVa1iaRUc9Lp"
+            "spotify:track:0VjIjW4GlUZAMYd2vXMi3b"
         ]
     }
 }
@@ -52,18 +59,23 @@ The id provided in the request.
 
 Always `result` on a successful request.
 
+### `success` (bool)
+
+`true` if the transaction was successful.
+
 ### `result` (dict)
 
 The result of the transaction.
 
 > #### `total` (int)
-> 
-> The total number of liked media (tracks) retrieved.
+>
+> The number of liked tracks retrieved.
 >
 > #### `account` (str)
-> 
-> The account used in the query.
-> 
+>
+> The id of the account used in the query.
+>
 > #### `tracks` (list[str])
-> 
-> List of Spotify URIs of the liked media (tracks) retrieved. Each entry in the list is a string representing a Spotify track URI. Refer to [URI Format](https://developer.spotify.com/documentation/> web-api/concepts/spotify-uris-ids) for details.
+>
+> The Spotify URIs of the liked tracks. Each entry is a track URI string. See [URI format](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids).
+>

--- a/docs/websocket/player.md
+++ b/docs/websocket/player.md
@@ -1,12 +1,12 @@
 # Player
 
-Provides the active playback state for a Spotify Account
+Provides the active playback state for a Spotify account.
 
 ## Request
 
 ```json
 {
-    "id": 6,
+    "id": 1,
     "type": "spotcast/player",
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF"
 }
@@ -14,141 +14,71 @@ Provides the active playback state for a Spotify Account
 
 ### `id` (int)
 
+*Required*
+
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/player`
+*Required*
+
+The endpoint of the WebSocket to reach. Must be `spotcast/player`.
 
 ### `account` (str)
 
 *Optional*
 
-The entry id of the account used to get the active playback state. Defaults to the default spotcast account if not provided.
+The `entry_id` of the account to use. Defaults to the default Spotcast account if not provided.
 
 ## Response
 
 ```json
 {
-    "id": 6,
+    "id": 1,
     "type": "result",
+    "success": true,
     "result": {
         "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
-        "state" : {
-        "device": {
-            "id": "12345",
-            "is_active": true,
-            "is_private_session": false,
-            "is_restricted": false,
-            "name": "foo",
-            "type": "Computer",
-            "volume_percent": 100,
-            "supports_volume": true
-        },
-        "repeat_state": "context",
-        "shuffle_state": false,
-        "context": {
-            "type": "album",
-            "href": "https://api.spotify.com/v1/albums/1chw1DFmefTueG1VbNVoGN",
-            "external_urls": {
-                "spotify": "https://open.spotify.com/album/1chw1DFmefTueG1VbNVoGN"
+        "state": {
+            "device": {
+                "id": "12345",
+                "is_active": true,
+                "is_private_session": false,
+                "is_restricted": false,
+                "name": "foo",
+                "type": "Computer",
+                "volume_percent": 100,
+                "supports_volume": true
             },
-            "uri": "spotify:album:1chw1DFmefTueG1VbNVoGN"
-        },
-        "timestamp": 1732541310670,
-        "progress_ms": 76425,
-        "is_playing": true,
-        "item": {
-            "album": {
-                "album_type": "album",
-                "total_tracks": 14,
+            "repeat_state": "context",
+            "shuffle_state": false,
+            "context": {
+                "type": "album",
+                "href": "https://api.spotify.com/v1/albums/1chw1DFmefTueG1VbNVoGN",
                 "external_urls": {
                     "spotify": "https://open.spotify.com/album/1chw1DFmefTueG1VbNVoGN"
                 },
-                "href": "https://api.spotify.com/v1/albums/1chw1DFmefTueG1VbNVoGN",
-                "id": "1chw1DFmefTueG1VbNVoGN",
-                "images": [
-                    {
-                        "url": "https://i.scdn.co/image/ab67616d0000b273d365d1c5923d54a868996ce8",
-                        "height": 640,
-                        "width": 640
-                    },
-                    {
-                        "url": "https://i.scdn.co/image/ab67616d00001e02d365d1c5923d54a868996ce8",
-                        "height": 300,
-                        "width": 300
-                    },
-                    {
-                        "url": "https://i.scdn.co/image/ab67616d00004851d365d1c5923d54a868996ce8",
-                        "height": 64,
-                        "width": 64
-                    }
-                ],
-                "name": "GREIF",
-                "release_date": "2024-08-23",
-                "release_date_precision": "day",
-                "type": "album",
-                "uri": "spotify:album:1chw1DFmefTueG1VbNVoGN",
-                "artists": [
-                    {
-                        "external_urls": {
-                            "spotify": "https://open.spotify.com/artist/6yCjbLFZ9qAnWfsy9ujm5Y"
-                        },
-                        "href": "https://api.spotify.com/v1/artists/6yCjbLFZ9qAnWfsy9ujm5Y",
-                        "id": "6yCjbLFZ9qAnWfsy9ujm5Y",
-                        "name": "Zeal & Ardor",
-                        "type": "artist",
-                        "uri": "spotify:artist:6yCjbLFZ9qAnWfsy9ujm5Y"
-                    }
-                ],
-                "is_playable": true
+                "uri": "spotify:album:1chw1DFmefTueG1VbNVoGN"
             },
-            "artists": [
-                {
-                    "external_urls": {
-                        "spotify": "https://open.spotify.com/artist/6yCjbLFZ9qAnWfsy9ujm5Y"
-                    },
-                    "href": "https://api.spotify.com/v1/artists/6yCjbLFZ9qAnWfsy9ujm5Y",
-                    "id": "6yCjbLFZ9qAnWfsy9ujm5Y",
-                    "name": "Zeal & Ardor",
-                    "type": "artist",
-                    "uri": "spotify:artist:6yCjbLFZ9qAnWfsy9ujm5Y"
+            "timestamp": 1732541310670,
+            "progress_ms": 76425,
+            "is_playing": true,
+            "item": {},
+            "currently_playing_type": "track",
+            "actions": {
+                "disallows": {
+                    "resuming": true
                 }
-            ],
-            "disc_number": 1,
-            "duration_ms": 231813,
-            "explicit": false,
-            "external_ids": {
-                "isrc": "QM4TW2489136"
             },
-            "external_urls": {
-                "spotify": "https://open.spotify.com/track/1Yk1xHfMPC43JQ5R8JO6Ia"
-            },
-            "href": "https://api.spotify.com/v1/tracks/1Yk1xHfMPC43JQ5R8JO6Ia",
-            "id": "1Yk1xHfMPC43JQ5R8JO6Ia",
-            "is_playable": true,
-            "name": "Fend You Off",
-            "popularity": 41,
-            "preview_url": "https://p.scdn.co/mp3-preview/8a04fe6a20961f18c01eb8b85ca390873764efa0?cid=cfe923b2d660439caf2b557b21f31221",
-            "track_number": 2,
-            "type": "track",
-            "uri": "spotify:track:1Yk1xHfMPC43JQ5R8JO6Ia",
-            "is_local": false
-        },
-        "currently_playing_type": "track",
-        "actions": {
-            "disallows": {
-                "resuming": true
-            }
-        },
-        "smart_shuffle": false
+            "smart_shuffle": false
+        }
     }
 }
 ```
 
 ### `id` (int)
 
-The id provided in the request
+The id provided in the request.
 
 ### `type` (str)
 
@@ -156,16 +86,17 @@ Always `result` on a successful request.
 
 ### `success` (bool)
 
-True if the transaction was successful.
+`true` if the transaction was successful.
 
 ### `result` (dict)
 
-The result of the query.
+The result of the transaction.
 
 > #### `account` (str)
 >
-> The account used in the query
+> The id of the account used in the query.
 >
 > #### `state` (dict)
 >
-> The current playback state. See the [API documentation](https://developer.spotify.com/documentation/web-api/reference/get-information-about-the-users-current-playback) for details of the fields. If no active playback. Returns an empty dictionary.
+> The current playback state. See [Get Playback State](https://developer.spotify.com/documentation/web-api/reference/get-information-about-the-users-current-playback) for the fields. Returns an empty dictionary when there is no active playback.
+>

--- a/docs/websocket/playlists.md
+++ b/docs/websocket/playlists.md
@@ -1,12 +1,12 @@
 # Playlists
 
-Provides the list of the user's playlists
+Provides the list of the user's playlists.
 
 ## Request
 
 ```json
 {
-    "id": 7,
+    "id": 1,
     "type": "spotcast/playlists",
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
     "limit": 20
@@ -15,37 +15,42 @@ Provides the list of the user's playlists
 
 ### `id` (int)
 
+*Required*
+
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
-The endpoint of the websocket to reach. Must be `spotcast/playlists`
+*Required*
+
+The endpoint of the WebSocket to reach. Must be `spotcast/playlists`.
 
 ### `account` (str)
 
 *Optional*
 
-The entry id of the account used to get the active playback state. Defaults to the default spotcast account if not provided.
+The `entry_id` of the account to use. Defaults to the default Spotcast account if not provided.
 
 ### `limit` (int)
 
 *Optional*
 
-Sets a limit to the number of playlists to retrieve
+Limits the number of playlists retrieved. Retrieves all playlists if not provided.
 
 ## Response
 
 ```json
 {
-    "id": 7,
+    "id": 1,
     "type": "result",
+    "success": true,
     "result": {
         "total": 20,
         "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
         "category": "user",
         "playlists": [
-            {...},
-            {...}
+            {},
+            {}
         ]
     }
 }
@@ -53,7 +58,7 @@ Sets a limit to the number of playlists to retrieve
 
 ### `id` (int)
 
-The id provided in the request
+The id provided in the request.
 
 ### `type` (str)
 
@@ -61,24 +66,25 @@ Always `result` on a successful request.
 
 ### `success` (bool)
 
-True if the transaction was successful.
+`true` if the transaction was successful.
 
 ### `result` (dict)
 
-The result of the transaction
+The result of the transaction.
 
 > #### `total` (int)
-> 
-> The total number of playlists retrieved
+>
+> The number of playlists retrieved.
 >
 > #### `account` (str)
 >
-> The account used in the query
+> The id of the account used in the query.
 >
 > #### `category` (str)
 >
-> Always `user`. Kept for backward compatibility with earlier versions that supported Browse Category drilldown (removed after Spotify deprecated the category playlists endpoint).
-> 
+> Always `user`. Kept for backward compatibility with earlier versions that supported Browse category drilldown (removed after Spotify deprecated the category playlists endpoint).
+>
 > #### `playlists` (list[dict])
-> 
-> List of the user's playlists. See [Get Playlist](https://developer.spotify.com/documentation/web-api/reference/get-playlist) for details about the fields
+>
+> The user's playlists. These are the raw Spotify playlist objects; see [Get Playlist](https://developer.spotify.com/documentation/web-api/reference/get-playlist) for the fields.
+>

--- a/docs/websocket/search.md
+++ b/docs/websocket/search.md
@@ -1,12 +1,12 @@
 # Search
 
-Search for playlists or tracks based on a query.
+Search for playlists, tracks, albums, or artists based on a query.
 
 ## Request
 
 ```json
 {
-    "id": 7,
+    "id": 1,
     "type": "spotcast/search",
     "query": "rock",
     "search_type": "playlist",
@@ -14,43 +14,52 @@ Search for playlists or tracks based on a query.
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF"
 }
 ```
+
 ### `id` (int)
+
+*Required*
 
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
+*Required*
+
 The endpoint of the WebSocket to reach. Must be `spotcast/search`.
 
 ### `query` (str)
 
-The search query string. This can be any term, such as a track name, album, artist, playlist name, or genre.
+*Required*
+
+The search query string. Any term such as a track name, album, artist, playlist name, or genre.
 
 ### `search_type` (str)
 
 *Optional*
 
-The type of search. Can be `playlist`, `track`, `album`, or `artist`. Defaults to `playlist` if not specified.
+The type of item to search for. One of `playlist`, `track`, `album`, or `artist`. Defaults to `playlist`.
 
 ### `limit` (int)
 
 *Optional*
 
-Sets a limit to the number of results to retrieve. Defaults to 10 if not specified.
+The maximum number of results to retrieve. Defaults to `10`.
 
 ### `account` (str)
 
 *Optional*
 
-The `entry_id` of the account to use for Spotcast. If empty, the default Spotcast account is used.
+The `entry_id` of the account to use. Defaults to the default Spotcast account if not provided.
 
 ## Response
+
 ```json
 {
-    "id": 7,
+    "id": 1,
     "type": "result",
+    "success": true,
     "result": {
-        "total": 5,
+        "total": 2,
         "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
         "playlists": [
             {
@@ -66,13 +75,12 @@ The `entry_id` of the account to use for Spotcast. If empty, the default Spotcas
                 "uri": "spotify:playlist:37i9dQZF1DX4UtD7rx6U8w",
                 "description": "Indie rock tracks",
                 "icon": "https://link_to_image.com"
-            },
-            {...},
-            {...}
+            }
         ]
     }
 }
 ```
+
 ### `id` (int)
 
 The id provided in the request.
@@ -81,39 +89,43 @@ The id provided in the request.
 
 Always `result` on a successful request.
 
+### `success` (bool)
+
+`true` if the transaction was successful.
+
 ### `result` (dict)
 
 The result of the transaction.
 
 > #### `total` (int)
-> 
-> The total number of results retrieved.
-> 
+>
+> The number of results retrieved.
+>
 > #### `account` (str)
-> 
-> The account used in the query.
-> 
+>
+> The id of the account used in the query.
+>
 > #### `playlists` (list[dict])
-> 
-> A list of search results based on the search type. The key name will change depending on the search type and could be `playlists`, `tracks`, `albums`, or `artists`.
-> 
+>
+> The search results. The key name depends on `search_type` and can be `playlists`, `tracks`, `albums`, or `artists`.
+>
 > > ##### `id` (str)
-> > 
-> > The unique ID for the result. For playlists, this will be the Spotify playlist ID. For tracks, it will be the Spotify track ID. For albums or artists, it will be the corresponding Spotify ID.
-> > 
+> >
+> > The Spotify ID of the result.
+> >
 > > ##### `name` (str)
-> > 
+> >
 > > The name of the playlist, track, album, or artist.
-> > 
+> >
 > > ##### `uri` (str)
-> > 
-> > The Spotify URI for the playlist, track, album, or artist. Refer to [URI Format](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids) for details.
-> > 
+> >
+> > The Spotify URI of the result. See [URI format](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids).
+> >
 > > ##### `description` (str)
-> > 
-> > A description of the playlist, track, album, or artist, if available.
-> > 
+> >
+> > A description of the result, if available.
+> >
 > > ##### `icon` (str)
-> > 
-> > A URL to an image associated with the playlist, track, album, or artist, if available.
-
+> >
+> > A URL to an image for the result, if available.
+> >

--- a/docs/websocket/tracks.md
+++ b/docs/websocket/tracks.md
@@ -6,35 +6,44 @@ Provides the list of tracks from a specified playlist.
 
 ```json
 {
-    "id": 15,
+    "id": 1,
     "type": "spotcast/tracks",
     "playlist_id": "spotify:playlist:37i9dQZF1DXcBWIGoYBM5M",
     "account": "01JDG07KSBTYWZGJSBJ1EW6XEF"
 }
 ```
+
 ### `id` (int)
+
+*Required*
 
 The id of the transaction. Must be an increment of the last transaction id.
 
 ### `type` (str)
 
+*Required*
+
 The endpoint of the WebSocket to reach. Must be `spotcast/tracks`.
 
 ### `playlist_id` (str)
 
-The Spotify ID or URI of the playlist whose tracks are to be retrieved. This can be a full URI such as `spotify:playlist:37i9dQZF1DXcBWIGoYBM5M` or just the playlist ID (`37i9dQZF1DXcBWIGoYBM5M`).
+*Required*
+
+The Spotify ID or URI of the playlist whose tracks are retrieved. Accepts a full URI such as `spotify:playlist:37i9dQZF1DXcBWIGoYBM5M` or just the ID (`37i9dQZF1DXcBWIGoYBM5M`).
 
 ### `account` (str)
 
 *Optional*
 
-The `entry_id` of the account to use for Spotcast. If empty, the default Spotcast account is used.
+The `entry_id` of the account to use. Defaults to the default Spotcast account if not provided.
 
 ## Response
+
 ```json
 {
-    "id": 15,
+    "id": 1,
     "type": "result",
+    "success": true,
     "result": {
         "total": 2,
         "account": "01JDG07KSBTYWZGJSBJ1EW6XEF",
@@ -43,18 +52,18 @@ The `entry_id` of the account to use for Spotcast. If empty, the default Spotcas
                 "id": "5J7j5w4UUMnGJ21rYVQfob",
                 "name": "The Nights",
                 "uri": "spotify:track:5J7j5w4UUMnGJ21rYVQfob",
-                "album": {...},
+                "album": {},
                 "artists": [
-                    {...},
-                    {...}
+                    {},
+                    {}
                 ]
             },
-            {...},
-            {...}
+            {}
         ]
     }
 }
 ```
+
 ### `id` (int)
 
 The id provided in the request.
@@ -63,39 +72,43 @@ The id provided in the request.
 
 Always `result` on a successful request.
 
+### `success` (bool)
+
+`true` if the transaction was successful.
+
 ### `result` (dict)
 
 The result of the transaction.
 
 > #### `total` (int)
 >
-> The total number of tracks retrieved.
+> The number of tracks retrieved.
 >
 > #### `account` (str)
 >
-> The account used in the query.
+> The id of the account used in the query.
 >
 > #### `tracks` (list[dict])
 >
-> List of tracks retrieved from the specified playlist. Each track includes:
+> The tracks retrieved from the playlist. Each track includes:
 >
 > > ##### `id` (str)
-> > 
+> >
 > > Spotify's unique ID for the track.
-> > 
+> >
 > > ##### `name` (str)
-> > 
+> >
 > > The name of the track.
-> > 
+> >
 > > ##### `uri` (str)
-> > 
-> > Spotify URI for the track. Refer to [URI Format](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids) for details.
-> > 
+> >
+> > The Spotify URI for the track. See [URI format](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids).
+> >
 > > ##### `album` (dict)
-> > 
-> > Information about the album the track belongs to. Refer to [Get playlist tracks](https://developer.spotify.com/documentation/web-api/reference/get-playlists-tracks) for details.
-> > 
+> >
+> > Information about the album the track belongs to. See [Get playlist items](https://developer.spotify.com/documentation/web-api/reference/get-playlists-tracks).
+> >
 > > ##### `artists` (list[dict])
-> > 
-> > List of artists who contributed to the track. Refer to [Get playlist tracks](https://developer.spotify.com/documentation/web-api/reference/get-playlists-tracks) for details.
-
+> >
+> > The artists who contributed to the track. See [Get playlist items](https://developer.spotify.com/documentation/web-api/reference/get-playlists-tracks).
+> >


### PR DESCRIPTION
Regenerates all nine websocket pages from a single template so they're clean and uniform.

## What was inconsistent
- Request `id`/`type` (and the required `query`/`playlist_id`) had no required/optional marker.
- Four response examples (`playlists`, `tracks`, `liked_media`, `search`) omitted `"success": true` and its field doc; the others included it.
- `devices` ordered its `result` fields differently from every other page.
- Transaction ids in the request vs response examples didn't match.

## Now uniform across all nine
- Standard envelope: `id` / `type` / `success` / `result`, same wording everywhere.
- Every request field marked **Required** or **Optional** (matching the service-docs convention).
- Consistent blockquote nesting for nested response fields.
- Every response example includes `"success": true`; matching request/response ids.

Each page's request schema and response shape were verified against its handler; every JSON example parses. Content (field descriptions, links) is preserved.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)