### PR TITLE
Enrich play_from_search and play_media docs with value lists and examples

### DIFF
--- a/docs/services/play_from_search.md
+++ b/docs/services/play_from_search.md
@@ -37,13 +37,21 @@ A generic search term that could be for any type of items
 
 *Required*
 
-A list of item types to look for in the search query.
+The item types to look for. The best match across the provided types is played (for `track`, several top results can be queued). One or more of:
+
+- `album`
+- `artist`
+- `playlist`
+- `track`
+- `show`
+- `episode`
+- `audiobook`
 
 ### `tags` (list[str])
 
 *Optional*
 
-A list of tags used to limit the search. Can only be used to search for albums:
+Tags used to narrow the search. They apply to album searches only. The only allowed tags are:
 
 - `hipster`: Limits results to albums with a popularity of less than 10%
 - `new`: Limits results to albums released in the past 2 weeks
@@ -82,3 +90,48 @@ Set of additional settings to apply when starting the playback. The available op
 | `repeat`   | `track \| context \| off` | `null`  | The repeat mode is kept the same if `null`                                                                                                  |
 | `shuffle`  | `bool`                    | `null`  | Sets the playback to shuffle if `True`. Is kept unchanged if `null`.                                                                        |
 | `limit`    | `positive_int`            | `1`     | Maximum number of items to retrieve per item type from the search. The first result is the one played                                       |
+
+## Examples
+
+### Play the top track for a search term
+
+```yaml
+action: spotcast.play_from_search
+data:
+    media_player:
+        entity_id: media_player.living_room
+    search_term: The Nights
+    item_types:
+        - track
+```
+
+### Narrow the search with filters
+
+`filters` are turned into Spotify `field:value` query modifiers (here `artist:The Drones year:2010-2019`).
+
+```yaml
+action: spotcast.play_from_search
+data:
+    media_player:
+        entity_id: media_player.living_room
+    search_term: Feelin Kinda Free
+    item_types:
+        - album
+    filters:
+        artist: The Drones
+        year: 2010-2019
+```
+
+### Play a brand-new album using a tag
+
+```yaml
+action: spotcast.play_from_search
+data:
+    media_player:
+        entity_id: media_player.living_room
+    search_term: synthwave
+    item_types:
+        - album
+    tags:
+        - new
+```

--- a/docs/services/play_media.md
+++ b/docs/services/play_media.md
@@ -51,3 +51,55 @@ Set of additional settings to apply when starting the playback. The available op
 
 > [!NOTE]
 > **Spotify editorial/algorithmic playlists** (the `spotify:playlist:37i9…` IDs - Daily Mix, Discover Weekly, Release Radar, song radios, etc.): Spotify no longer serves these playlists' contents through the public Web API, so `random` cannot read the track count from there. For them it resolves the real track count through Spotify's internal metadata endpoint and picks a random start across the **whole playlist**. Only if that endpoint is unavailable does it fall back to a random start within the first 25 tracks (emitted as a log warning). Regular playlists are unaffected.
+
+## Examples
+
+### Play an album
+
+```yaml
+action: spotcast.play_media
+data:
+    media_player:
+        entity_id: media_player.living_room
+    spotify_uri: spotify:album:1chw1DFmefTueG1VbNVoGN
+```
+
+### Play only a single track
+
+A track URI plays inside its album by default. Set `track_context: track` to play just the song.
+
+```yaml
+action: spotcast.play_media
+data:
+    media_player:
+        entity_id: media_player.living_room
+    spotify_uri: spotify:track:5J7j5w4UUMnGJ21rYVQfob
+    data:
+        track_context: track
+```
+
+### Play a track inside a specific playlist
+
+Start on a track but keep the playlist going afterwards by passing the playlist URI as `track_context`. The track must be part of that playlist.
+
+```yaml
+action: spotcast.play_media
+data:
+    media_player:
+        entity_id: media_player.living_room
+    spotify_uri: spotify:track:5J7j5w4UUMnGJ21rYVQfob
+    data:
+        track_context: spotify:playlist:37i9dQZF1DXcBWIGoYBM5M
+```
+
+### Start a playlist at a random track
+
+```yaml
+action: spotcast.play_media
+data:
+    media_player:
+        entity_id: media_player.living_room
+    spotify_uri: spotify:playlist:37i9dQZF1DXcBWIGoYBM5M
+    data:
+        random: true
+```


### PR DESCRIPTION
Docs-only. Adds the concrete values and worked examples the reference pages were missing.

## play_from_search
- Lists all seven allowed `item_types` (`album`, `artist`, `playlist`, `track`, `show`, `episode`, `audiobook`).
- Clarifies that the only two `tags` are `hipster` and `new` (album searches only).
- Adds three examples where the syntax genuinely differs: top track for a search term, narrowing an album search with `filters`, and finding a brand-new album with a `tag`.

## play_media
- Adds four examples: playing an album, playing a single track (`track_context: track`), playing a track inside a specific playlist (`track_context: spotify:playlist:...`), and starting a playlist at a random track (`random: true`).

Values verified against `spotify/search_query.py` (`ALLOWED_ITEM_TYPE`, `ALLOWED_TAGS`, `ALLOWED_FILTERS`) and `services/utils.py` (`track_context`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)