### PR TITLE
Add unlike_media service to remove tracks from the library

### DIFF
--- a/custom_components/spotcast/services.yaml
+++ b/custom_components/spotcast/services.yaml
@@ -290,3 +290,21 @@ like_media:
       selector:
         config_entry:
           integration: spotcast
+
+unlike_media:
+  name: Unlike Media
+  description: Remove a list of Media from your Spotify Library
+  fields:
+    spotify_uris:
+      name: Spotify URIs
+      description: A list of Spotify URIs
+      required: true
+      selector:
+        object:
+    account:
+      name: Spotify Account
+      description: The id of the spotify account to use. Takes the default account otherwise
+      required: false
+      selector:
+        config_entry:
+          integration: spotcast

--- a/custom_components/spotcast/services/const.py
+++ b/custom_components/spotcast/services/const.py
@@ -38,6 +38,10 @@ from custom_components.spotcast.services.like_media import (
     LIKE_MEDIA_SCHEMA,
     async_like_media,
 )
+from custom_components.spotcast.services.unlike_media import (
+    UNLIKE_MEDIA_SCHEMA,
+    async_unlike_media,
+)
 
 SERVICE_SCHEMAS = MappingProxyType({
     "play_media": PLAY_MEDIA_SCHEMA,
@@ -49,6 +53,7 @@ SERVICE_SCHEMAS = MappingProxyType({
     "add_to_queue": ADD_TO_QUEUE_SCHEMA,
     "play_saved_episodes": PLAY_SAVED_EPISODES,
     "like_media": LIKE_MEDIA_SCHEMA,
+    "unlike_media": UNLIKE_MEDIA_SCHEMA,
 })
 
 SERVICE_HANDLERS = MappingProxyType({
@@ -60,5 +65,6 @@ SERVICE_HANDLERS = MappingProxyType({
     "play_from_search": async_play_from_search,
     "add_to_queue": async_add_to_queue,
     "play_saved_episodes": async_play_saved_episodes,
-    "like_media": async_like_media
+    "like_media": async_like_media,
+    "unlike_media": async_unlike_media,
 })

--- a/custom_components/spotcast/services/unlike_media.py
+++ b/custom_components/spotcast/services/unlike_media.py
@@ -1,0 +1,37 @@
+"""Module to unlike a (list) of spotify uris
+
+Functions:
+    - async_unlike_media
+"""
+
+from logging import getLogger
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+import voluptuous as vol
+
+from custom_components.spotcast.spotify import SpotifyAccount
+from custom_components.spotcast.utils import get_account_entry
+from custom_components.spotcast.spotify.utils import url_to_uri
+
+LOGGER = getLogger(__name__)
+
+UNLIKE_MEDIA_SCHEMA = vol.Schema({
+    vol.Required("spotify_uris"): vol.All(cv.ensure_list, [url_to_uri]),
+    vol.Optional("account"): cv.string,
+})
+
+
+async def async_unlike_media(hass: HomeAssistant, call: ServiceCall):
+    """Service to remove a (list) of spotify uris from the library"""
+    uris = call.data.get("spotify_uris")
+    account_id = call.data.get("account")
+
+    entry = get_account_entry(hass, account_id)
+    LOGGER.debug("Loading Spotify Account for User `%s`", account_id)
+    account = await SpotifyAccount.async_from_config_entry(
+        hass=hass,
+        entry=entry
+    )
+
+    await account.async_unlike_media(uris)

--- a/custom_components/spotcast/spotify/account/library.py
+++ b/custom_components/spotcast/spotify/account/library.py
@@ -342,3 +342,19 @@ class LibraryMixin:
                 self.apis["public"].current_user_saved_tracks_add,
                 uris,
             )
+
+    async def async_unlike_media(self, uris: list[str]):
+        """Removes a list of uris from the user's liked songs."""
+        await self.async_ensure_tokens_valid()
+
+        dataset = self._datasets["liked_songs"]
+
+        # Force expire the liked_songs dataset
+        async with dataset.lock:
+            dataset.expires_at = 0
+            LOGGER.debug("Expired liked_songs dataset after removing likes")
+
+            await self.hass.async_add_executor_job(
+                self.apis["public"].current_user_saved_tracks_delete,
+                uris,
+            )

--- a/custom_components/spotcast/strings.json
+++ b/custom_components/spotcast/strings.json
@@ -116,6 +116,20 @@
                 }
             }
         },
+        "unlike_media": {
+            "name": "Unlike Media",
+            "description": "Remove a list of media from your Spotify Library",
+            "fields": {
+                "spotify_uris": {
+                    "name": "Spotify URIs",
+                    "description": "A list of media to remove from the Spotify Library"
+                },
+                "account": {
+                    "name": "Spotify Account",
+                    "description": "The ID of the Spotify account to use. Takes the default account otherwise."
+                }
+            }
+        },
         "play_custom_context": {
             "name": "Play Custom Context",
             "description": "Starts playback from a custom list of tracks URIs",

--- a/custom_components/spotcast/translations/en.json
+++ b/custom_components/spotcast/translations/en.json
@@ -116,6 +116,20 @@
                 }
             }
         },
+        "unlike_media": {
+            "name": "Unlike Media",
+            "description": "Remove a list of media from your Spotify Library",
+            "fields": {
+                "spotify_uris": {
+                    "name": "Spotify URIs",
+                    "description": "A list of media to remove from the Spotify Library"
+                },
+                "account": {
+                    "name": "Spotify Account",
+                    "description": "The ID of the Spotify account to use. Takes the default account otherwise."
+                }
+            }
+        },
         "play_custom_context": {
             "name": "Play Custom Context",
             "description": "Starts playback from a custom list of tracks URIs",

--- a/custom_components/spotcast/translations/fr.json
+++ b/custom_components/spotcast/translations/fr.json
@@ -116,6 +116,20 @@
                 }
             }
         },
+        "unlike_media": {
+            "name": "Retirer un Média",
+            "description": "Retire une liste de média de la librairie Spotify.",
+            "fields": {
+                "spotify_uris": {
+                    "name": "URIs Spotify",
+                    "description": "Une liste de média à retirer de la librairie Spotify."
+                },
+                "account": {
+                    "name": "Compte Spotify",
+                    "description": "L'ID du compte Spotify à utiliser. Utilise le compte par défaut sinon."
+                }
+            }
+        },
         "play_custom_context": {
             "name": "Lire un context personalisé",
             "description": "Démarre une lecture avec une liste personalisé de chansons.",

--- a/docs/services/unlike_media.md
+++ b/docs/services/unlike_media.md
@@ -1,0 +1,25 @@
+# Unlike Media
+
+Remove a list of Spotify URIs from a specific Spotify account's library.
+
+## Action
+
+```yaml
+action: spotcast.unlike_media
+data:
+    spotify_uris:
+        - spotify:track:1yuxSH79Cj1nGqN1AKD9p5
+        - spotify:track:2dbJ0mn0vTVz6mc3rk2t77
+    account: 01JDG07KSBTYWZGJSBJ1EW6XEF
+```
+### `spotify_uris` (list[str])
+
+*Required*
+
+A list of Spotify track URIs or URLs to remove from the library. This is the counterpart to [`like_media`](./like_media.md).
+
+### `account` (str)
+
+*Optional*
+
+The `entry_id` of the account to use for Spotcast. If empty, the default Spotcast account is used.

--- a/test/services/unlike_media/__init__.py
+++ b/test/services/unlike_media/__init__.py
@@ -1,0 +1,1 @@
+TEST_MODULE = "custom_components.spotcast.services.unlike_media"

--- a/test/services/unlike_media/test_async_unlike_media.py
+++ b/test/services/unlike_media/test_async_unlike_media.py
@@ -1,0 +1,44 @@
+"""Module to test the async_unlike_media function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from custom_components.spotcast.services.unlike_media import (
+    async_unlike_media,
+    SpotifyAccount,
+    ServiceCall,
+    HomeAssistant,
+)
+
+from test.services.unlike_media import TEST_MODULE
+
+
+class TestUnlikingMedia(IsolatedAsyncioTestCase):
+
+    @patch.object(SpotifyAccount, "async_from_config_entry")
+    @patch(f"{TEST_MODULE}.get_account_entry", new_callable=MagicMock)
+    async def asyncSetUp(self, mock_entry: MagicMock, mock_account: AsyncMock):
+
+        mock_account.return_value = MagicMock(spec=SpotifyAccount)
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "call": MagicMock(spec=ServiceCall),
+            "account": mock_account.return_value,
+        }
+
+        self.mocks["account"].async_unlike_media = AsyncMock()
+
+        self.mocks["call"].data = {
+            "spotify_uris": ["foo", "bar", "baz"]
+        }
+
+        await async_unlike_media(self.mocks["hass"], self.mocks["call"])
+
+    def test_unlike_media_properly_called(self):
+        try:
+            self.mocks["account"].async_unlike_media.assert_called_with(
+                ["foo", "bar", "baz"]
+            )
+        except AssertionError:
+            self.fail()

--- a/test/spotify/account/test_async_unlike_media.py
+++ b/test/spotify/account/test_async_unlike_media.py
@@ -1,0 +1,70 @@
+"""Module to test the async_unlike_media function"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from custom_components.spotcast.spotify.account import (
+    SpotifyAccount,
+    PublicSession,
+    DesktopSession,
+    HomeAssistant,
+    Spotify,
+    Store,
+)
+
+from test.spotify.account import TEST_MODULE
+
+
+class TestUnlikeSongs(IsolatedAsyncioTestCase):
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_spotify: MagicMock,
+            mock_store: MagicMock,
+    ):
+
+        self.mocks = {
+            "internal": MagicMock(spec=DesktopSession),
+            "external": MagicMock(spec=PublicSession),
+            "hass": MagicMock(spec=HomeAssistant),
+        }
+        self.mocks["hass"].loop = MagicMock()
+
+        self.mock_spotify = mock_spotify
+
+        self.mocks["external"].token = {
+            "access_token": "12345",
+            "expires_at": 12345.61,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+            is_default=True
+        )
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock()
+
+        self.account._datasets["liked_songs"].expires_at = 9999
+
+        self.result = await self.account.async_unlike_media([
+            "foo",
+            "bar",
+            "baz",
+        ])
+
+    def test_executor_properly_called(self):
+        try:
+            self.mocks["hass"].async_add_executor_job.assert_called_with(
+                self.account.apis["public"].current_user_saved_tracks_delete,
+                ["foo", "bar", "baz"]
+            )
+        except AssertionError:
+            self.fail()
+
+    def test_liked_songs_dataset_set_to_expired(self):
+        self.assertEqual(self.account._datasets["liked_songs"].expires_at, 0)


### PR DESCRIPTION
## What

Adds a `spotcast.unlike_media` service - the symmetric counterpart to `like_media`. The library could be added to but never trimmed; an automation that auto-likes now has a way to auto-unlike.

## Changes

- **`spotify/account/library.py`** - `async_unlike_media` calls the public Web API `current_user_saved_tracks_delete` and expires the `liked_songs` dataset, exactly mirroring `async_like_media`'s add path.
- **`services/unlike_media.py`** - service entry point, same schema as `like_media` (`spotify_uris` required, `account` optional).
- **`services/const.py`** - registered in `SERVICE_SCHEMAS`/`SERVICE_HANDLERS` (registration is data-driven, so this is all that's needed).
- **Metadata/docs** - `services.yaml`, `strings.json`, `en`/`fr` translations, and `docs/services/unlike_media.md`.

## Scope

Kept deliberately minimal and symmetric with `like_media`: tracks only, public token, no new auth. Removing albums/shows/episodes is intentionally out of scope (neither does `like_media`).

## Tests

- Service forwards URIs to `account.async_unlike_media`.
- Account method calls `current_user_saved_tracks_delete` and expires the liked_songs dataset.
- Full suite green (691 tests). Pylint 10.00/10 on the changed files; all translation JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)