### PR TITLE
Release v6.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.4.0
+current_version = 6.5.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[^\d]*)(?P<build>\d+))?
 serialize = 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import DEFAULT_OPTIONS
 from .spotify import SpotifyAccount
 from .coordinator import SpotcastCoordinator
 
-__version__ = "6.4.0"
+__version__ = "6.5.0"
 
 
 LOGGER = getLogger(__name__)

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -22,5 +22,5 @@
         "spotipy>=2.26.0",
         "RapidFuzz>=3.14.5"
     ],
-    "version": "6.4.0"
+    "version": "6.5.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotcast"
-version = "6.4.0"
+version = "6.5.0"
 description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for Chromecast as well as Spotify Connect devices."
 readme = "README.md"
 requires-python = ">=3.14.2"
@@ -18,7 +18,7 @@ dependencies = [
     "requests>=2.33.1",
     "spotifyaio>=2.0.2",
     "RapidFuzz>=3.14.5",
-    "homeassistant>=2026.4.0",
+    "homeassistant>=2026.5.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Version bump to **6.5.0**.

## Highlights since v6.4.0

### Features
- **Chromecast speaker group support** (#45) - starting playback on a Google Cast speaker group now declares the group correctly, waits for it to settle, and targets non-Google groups by the id they register under.
- **`unlike_media` service** (#46) - remove tracks from the library, the symmetric counterpart to `like_media`.

### Docs
- Rebuilt the websocket docs to one consistent structure (#43).
- Enriched `play_from_search` / `play_media` with value lists and worked examples (#44).
- Documented `track_context` and made every service field's required/optional marker consistent (#41, #42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)