### PR TITLE
List unlike_media in the README and architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Follow the [configuration guide](./docs/config/spotcast_configuration.md) or cli
 | [spotcast.transfer_playback](./docs/services/transfer_playback.md)     | Transfers the active or most recent playback to the provided device.                                 |
 | [spotcast.add_to_queue](./docs/services/add_to_queue.md)               | Adds songs to the playback queue. Fails and returns an error if there is no active playback.         |
 | [spotcast.like_media](./docs/services/like_media.md)                   | Adds a list of media URIs to the user's liked content.                                               |
+| [spotcast.unlike_media](./docs/services/unlike_media.md)               | Removes a list of track URIs from the user's liked content.                                          |
 
 ### Data
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -348,7 +348,7 @@ The action layer is a thin dispatcher. `ServiceHandler`
 `services/const.py::SERVICE_SCHEMAS` and routes each call to its handler.
 The current actions are: `play_media`, `play_dj`, `play_liked_songs`,
 `transfer_playback`, `play_custom_context`, `play_from_search`,
-`add_to_queue`, `play_saved_episodes`, and `like_media`.
+`add_to_queue`, `play_saved_episodes`, `like_media`, and `unlike_media`.
 
 Each action optionally takes an `account` id and falls back to the default
 account otherwise, resolves the target media player, and calls the


### PR DESCRIPTION
Docs-only follow-up to v6.5.0. The `unlike_media` service (PR #46) shipped with its own doc page, `services.yaml`, `strings.json`, and translations, but was missing from:

- the README services table, and
- the architecture doc's list of current actions.

Both now list it. No code or functionality change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)