### PR TITLE
Label the HACS listing "Spotcast (maintained)"

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-    "name": "Spotcast",
+    "name": "Spotcast (maintained)",
     "homeassistant": "2026.4.0"
 }


### PR DESCRIPTION
Both this fork and the legacy repo show as **Spotcast** in the HACS list, which makes them impossible to tell apart at a glance.

`hacs.json`'s `name` only controls the HACS UI label; it does not rename the integration inside Home Assistant (that comes from `manifest.json` / `strings.json`, still "Spotcast"). So this differentiates the maintained fork in the list without affecting anything post-install.

Paired with a refreshed GitHub repo description (the HACS subtitle) for extra clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)