### PR TITLE
Fix the license badge rendering in HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![release](https://img.shields.io/github/v/release/Mincka/spotcast?include_prereleases)](https://github.com/Mincka/spotcast/releases)
 [![tests](https://github.com/Mincka/spotcast/actions/workflows/unittest.yml/badge.svg?branch=main)](https://github.com/Mincka/spotcast/actions/workflows/unittest.yml)
-[![license](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
+[![license](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/Mincka/spotcast/blob/main/LICENSE)
 ![maintenance](https://img.shields.io/maintenance/yes/2026.svg)
 
 Spotcast is a Home Assistant custom integration that starts Spotify playback on an idle Chromecast or Spotify Connect device, so your automations can target both device families the same way.


### PR DESCRIPTION
The license badge failed to render on the HACS repository page, while the `release` badge (same `img.shields.io` host) rendered fine, so it is not shields.io blocking by referrer.

The license badge was the only one that combined two oddities: a `.svg`-suffixed shields URL and a **relative** `./LICENSE` link. This makes it identical in form to the working `release` badge: drop the `.svg` suffix and use the absolute `LICENSE` URL.

Docs-only. Note: the GitHub repo page shows this immediately; HACS renders the README from the latest release, so it will reflect there on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)