### PR TITLE
Release v6.5.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.5.1
+current_version = 6.5.2
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[^\d]*)(?P<build>\d+))?
 serialize = 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import DEFAULT_OPTIONS
 from .spotify import SpotifyAccount
 from .coordinator import SpotcastCoordinator
 
-__version__ = "6.5.1"
+__version__ = "6.5.2"
 
 
 LOGGER = getLogger(__name__)

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -22,5 +22,5 @@
         "spotipy>=2.26.0",
         "RapidFuzz>=3.14.5"
     ],
-    "version": "6.5.1"
+    "version": "6.5.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotcast"
-version = "6.5.1"
+version = "6.5.2"
 description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for Chromecast as well as Spotify Connect devices."
 readme = "README.md"
 requires-python = ">=3.14.2"
@@ -18,7 +18,7 @@ dependencies = [
     "requests>=2.33.1",
     "spotifyaio>=2.0.2",
     "RapidFuzz>=3.14.5",
-    "homeassistant>=2026.5.1",
+    "homeassistant>=2026.5.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Patch release so the HACS page picks up the license-badge fix (HACS renders the README from the latest release tag).

## Since v6.5.1
- Fix the license badge rendering on the HACS repository page (#51). The badge used a relative `./LICENSE` link, which triggers HACS's frontend to rewrite the image URL into a dead `raw.githubusercontent.com/.../https://img.shields.io/...` path (404). Using an absolute link leaves the image untouched.

No functional code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)