### PR TITLE
Use a plain logo image so HACS doesn't show raw <picture> markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./assets/images/logo/white/128.png">
-  <source media="(prefers-color-scheme: light)" srcset="./assets/images/logo/dark_gray/128.png">
-  <img alt="Spotcast" src="https://raw.githubusercontent.com/Mincka/spotcast/main/assets/images/logo/green/128.png">
-</picture>
+<img alt="Spotcast" src="https://raw.githubusercontent.com/Mincka/spotcast/main/assets/images/logo/green/128.png">
 
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
HACS's README renderer doesn't support `<picture>`/`<source>`, so it printed those tags as literal text above the logo on the repository page (only the `<img>` fallback rendered).

Drop the theme-switching `<picture>` wrapper and keep the green logo (the existing fallback), which reads on both light and dark backgrounds.

Tradeoff: GitHub loses the dark/light adaptive logo swap and shows the green logo on both themes. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)