### PR TITLE
README: fold the upgrade section into the migration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spotcast is a Home Assistant custom integration that starts Spotify playback on 
 
 Welcome, and thanks for sticking with Spotcast. Whether you ran it for years on v4 or tried the v6 alphas, this is where the project lives now and it is actively maintained again. Here is how to come over depending on where you are:
 
-- **If your old Spotcast (v4) stopped working** with login loops, reauthentication failures, or errors like `400 Bad Request` on `accounts.spotify.com/api/token` or `ServerTime`, that is not your setup: Spotify changed its authentication on their side and the old cookie-based method can no longer work. **The v6 rewrite is the fix.** It was only ever published as a pre-release on the original repository, so HACS never offered it to you as an update, which is exactly why moving here matters. v6 is a ground-up rewrite with a new setup flow (the old `sp_dc`/`sp_key` YAML is gone), so you will configure it once by following the [configuration guide](./docs/config/spotcast_configuration.md).
+- **If your old Spotcast (v4) stopped working** with login loops, reauthentication failures, or errors like `400 Bad Request` on `accounts.spotify.com/api/token` or `ServerTime`, that is not your setup: Spotify changed its authentication on their side and the old cookie-based method can no longer work. **The v6 rewrite is the fix.** It was only ever published as a pre-release on the original repository, so HACS never offered it to you as an update, which is exactly why moving here matters. v6 is a ground-up rewrite with a new setup flow (the old `sp_dc`/`sp_key` YAML is gone), so you will configure it once by following the [configuration guide](./docs/config/spotcast_configuration.md). Your automations need a one-time update too: the `spotcast.start` service was replaced by a set of dedicated actions, the closest equivalent being [`spotcast.play_media`](./docs/services/play_media.md) with most of its former options now under the `data` section, and `spotcast.play_category` was removed following the deprecation of the corresponding Spotify Web API endpoints.
 - **If you were already on a v6 alpha or beta**, switching here is a clean swap on the same major version: your accounts, tokens, entities and automations carry over untouched.
 
 To move over in HACS: remove the existing Spotcast download from **HACS only** (do **not** delete the integration from *Settings -> Devices & Services*, that would erase your configuration), then add this repository as a [custom repository](#hacs-custom-repository) and download it. Home Assistant keys your configuration to the `spotcast` integration itself, not to the repository it came from, so a same-version reinstall picks your existing setup right back up. Restart Home Assistant when done.
@@ -161,14 +161,6 @@ Spotcast provides multiple WebSocket API endpoints, used for example by companio
 | [`spotcast/playlists`](./docs/websocket/playlists.md)       | Provides the list of the user's playlists.                                                                                                      |
 | [`spotcast/search`](./docs/websocket/search.md)             | Searches Spotify for playlists, tracks, albums or artists.                                                                                      |
 | [`spotcast/tracks`](./docs/websocket/tracks.md)             | Provides the list of tracks in a playlist.                                                                                                      |
-
-## Upgrading from v4
-
-v5 was a beta-only rewrite that never reached a stable release, so most users upgrade straight from v4. The rewrite changed both the configuration flow and the action names:
-
-- Configuration no longer uses `sp_dc`/`sp_key` cookies in YAML. Accounts are set up through the UI with OAuth and a one-time desktop authorization. Follow the [configuration guide](./docs/config/spotcast_configuration.md).
-- The `spotcast.start` service was replaced by a set of dedicated actions. The closest equivalent to `spotcast.start` is [`spotcast.play_media`](./docs/services/play_media.md), with most of its former options now under the `data` section.
-- `spotcast.play_category` was removed, following the deprecation of the corresponding Spotify Web API endpoints.
 
 ## Related projects
 


### PR DESCRIPTION
Follow-up to #58: the whole "Upgrading from v4" section was redundant with "Coming from the original fondberg/spotcast?". Its only unique content (the `spotcast.start` -> `play_media` mapping and the `play_category` removal) moves into that section's v4 bullet; the section itself is removed.

Docs only, no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)