### PR TITLE
Retry once with a fresh token when Spotify replies 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This repository is the continuation of the original [fondberg/spotcast](https://github.com/fondberg/spotcast) project. For the history of releases prior to v6, see the [original project's releases](https://github.com/fondberg/spotcast/releases). Releases v6.3.0 through v6.5.2 are documented in the [GitHub release notes](https://github.com/Mincka/spotcast/releases).
 
+## Unreleased
+
+### Fixes
+
+- A `401` from the Spotify API on a token the session still considers valid no longer surfaces as a coordinator error: the account forces a token refresh and retries the call once. Spotify occasionally rejects a freshly refreshed token (`Access token missing`), which previously failed the whole update cycle.
+- The desktop session keeps its refresh token when Spotify omits `refresh_token` from a refresh response. The response replaced the stored token wholesale, which would have left the session permanently unable to refresh.
+
 ## v6.5.3 (2026-07-16)
 
 ### Fixes

--- a/custom_components/spotcast/sessions/connection_session.py
+++ b/custom_components/spotcast/sessions/connection_session.py
@@ -113,15 +113,21 @@ class ConnectionSession(ABC):
         `expires_in` standard key.
         """
 
-    async def async_ensure_token_valid(self) -> bool:
+    async def async_ensure_token_valid(self, force: bool = False) -> bool:
         """Method that ensures a token is currently valid.
+
+        Args:
+            force(bool, optional): Refreshes the token even if it is not
+                expired yet. Used to recover from an API rejecting a
+                token the session still considers valid. Defaults to
+                False.
 
         Returns:
             bool: Returns `True` if the token was refreshed and `False`
                 if not
         """
         async with self._token_lock:
-            if self.valid_token:
+            if self.valid_token and not force:
                 return False
 
             if not self.supervisor.is_ready:

--- a/custom_components/spotcast/sessions/desktop_session.py
+++ b/custom_components/spotcast/sessions/desktop_session.py
@@ -70,4 +70,9 @@ class DesktopSession(ConnectionSession):
 
         # sets the new expires at key
         data["expires_at"] = data.pop("expires_in") + time()
-        return data
+
+        # the response replaces the whole token, so merge it over the
+        # current one: Spotify may omit `refresh_token` when it is still
+        # valid, which would otherwise leave the session unable to
+        # refresh ever again.
+        return {**self.token, **data}

--- a/custom_components/spotcast/spotify/account/__init__.py
+++ b/custom_components/spotcast/spotify/account/__init__.py
@@ -5,6 +5,7 @@ Classes:
 """
 
 from asyncio import Lock
+from functools import partial
 from logging import getLogger
 
 from spotipy import SpotifyException
@@ -204,7 +205,10 @@ class SpotifyAccount(  # pylint: disable=too-many-instance-attributes
         self.apis: dict[str, Spotify] = {}
 
         for name, session in self.sessions.items():
-            self.apis[name] = Spotify(auth=session.access_token)
+            self.apis[name] = Spotify(
+                auth=session.access_token,
+                token_refresher=partial(self.get_token, name, force=True),
+            )
 
         self.is_default = is_default
         self._base_refresh_rate = base_refresh_rate

--- a/custom_components/spotcast/spotify/account/token.py
+++ b/custom_components/spotcast/spotify/account/token.py
@@ -30,31 +30,38 @@ class TokenMixin:
 
         return health
 
-    def get_token(self, api: str) -> str:
+    def get_token(self, api: str, force: bool = False) -> str:
         """Retrives a token from the requested session.
+
+        Safe to call from an executor thread, which is where the
+        spotipy clients run.
 
         Args:
             api(str): The session to retrieve from. Can be `public`
                 or `private`.
+            force(bool, optional): Refreshes the token even if it is
+                not expired yet. Defaults to False.
 
         Returns:
             str: token for the requested session
         """
         return run_coroutine_threadsafe(
-            self.async_get_token(api), self.hass.loop
+            self.async_get_token(api, force), self.hass.loop
         ).result()
 
-    async def async_get_token(self, api: str) -> str:
+    async def async_get_token(self, api: str, force: bool = False) -> str:
         """Retrives a token from the requested session.
 
         Args:
             api(str): The session to retrieve from. Can be `public` or
                 `private`.
+            force(bool, optional): Refreshes the token even if it is
+                not expired yet. Defaults to False.
 
         Returns:
             - str: token for the requested session
         """
-        await self.sessions[api].async_ensure_token_valid()
+        await self.sessions[api].async_ensure_token_valid(force)
         return self.sessions[api].access_token
 
     async def async_ensure_tokens_valid(

--- a/custom_components/spotcast/spotify/client.py
+++ b/custom_components/spotcast/spotify/client.py
@@ -4,14 +4,79 @@ Classes:
     - Spotify
 """
 
+from collections.abc import Callable
+from logging import getLogger
+from typing import Any
+
 from spotipy import Spotify as SpotipyClient
+from spotipy.exceptions import SpotifyException
+
+LOGGER = getLogger(__name__)
 
 
 class Spotify(SpotipyClient):
     """spotipy client extended with the Spotify Web API endpoints
     introduced by the February 2026 platform changes, which spotipy
     does not wrap. The old endpoints are removed for client ids
-    created after 2026-02-11 (older ids are grandfathered)."""
+    created after 2026-02-11 (older ids are grandfathered).
+
+    Also retries once with a freshly refreshed token when the API
+    rejects a token the session still considers valid.
+    """
+
+    def __init__(
+        self,
+        *args,
+        token_refresher: Callable[[], str] | None = None,
+        **kwargs,
+    ):
+        """Constructor of the extended spotipy client.
+
+        Args:
+            token_refresher(Callable, optional): Called from the
+                executor thread to obtain a freshly refreshed access
+                token after a 401. Retries are disabled when omitted.
+        """
+        super().__init__(*args, **kwargs)
+        self._token_refresher = token_refresher
+
+    def _internal_call(
+        self,
+        method: str,
+        url: str,
+        payload: Any,
+        params: dict,
+    ) -> Any:
+        """Performs the api call, retrying once on an unexpected 401.
+
+        A 401 is expected when the token is expired, but the account
+        refreshes it before every call. Spotify still occasionally
+        rejects a valid token, in which case a forced refresh recovers
+        instead of surfacing the failure to the user.
+        """
+        try:
+            return super()._internal_call(method, url, payload, params)
+        except SpotifyException as exc:
+            if exc.http_status != 401 or self._token_refresher is None:
+                raise
+
+            LOGGER.warning(
+                "Spotify rejected the access token for %s. Forcing a "
+                "token refresh and retrying once",
+                url,
+            )
+
+            try:
+                token = self._token_refresher()
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception(
+                    "Could not refresh the access token after a 401"
+                )
+                raise exc from None
+
+            self.set_auth(token)
+
+            return super()._internal_call(method, url, payload, params)
 
     def save_to_library(self, uris: list[str]) -> dict:
         """Saves a list of Spotify URIs to the user's library.

--- a/test/sessions/desktop_session/test_async_refresh_token.py
+++ b/test/sessions/desktop_session/test_async_refresh_token.py
@@ -57,6 +57,51 @@ class TestSuccessfullRefresh(IsolatedAsyncioTestCase):
         )
 
 
+class TestRefreshWithoutNewRefreshToken(IsolatedAsyncioTestCase):
+    """Spotify may omit `refresh_token` when the current one stays
+    valid. The session must keep it instead of dropping it."""
+
+    @patch(f"{TEST_MODULE}.time", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.async_get_clientsession", new_callable=MagicMock)
+    async def asyncSetUp(
+        self,
+        mock_http_session: MagicMock,
+        mock_time: MagicMock,
+    ):
+
+        mock_http_session.return_value = MagicMock(spec=ClientSession)
+
+        self.session, self.mocks = get_mocked_session()
+
+        self.mocks["http_session"] = mock_http_session.return_value
+        self.mocks["time"] = mock_time
+        self.mocks["time"].return_value = 400
+
+        self.mocks["http_session"].post = AsyncMock()
+        self.mocks["http_session"].post.return_value = MagicMock()
+        self.mocks["response"] = self.mocks["http_session"].post.return_value
+        self.mocks["response"].json = AsyncMock()
+        self.mocks["response"].json.return_value = {
+            "access_token": "baz",
+            "expires_in": 100,
+            "scope": "read write",
+        }
+        self.mocks["response"].status = 200
+
+        self.result = await self.session.async_refresh_token()
+
+    def test_refresh_token_retained(self):
+        self.assertEqual(
+            self.result,
+            {
+                "access_token": "baz",
+                "refresh_token": "bar",
+                "expires_at": 500,
+                "scope": "read write",
+            }
+        )
+
+
 class TestStandardFormatErrorMessage(IsolatedAsyncioTestCase):
 
     @patch(f"{TEST_MODULE}.LOGGER", new_callable=MagicMock)

--- a/test/spotify/test_client.py
+++ b/test/spotify/test_client.py
@@ -3,7 +3,16 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from custom_components.spotcast.spotify.client import Spotify
+from spotipy import Spotify as SpotipyClient
+
+from custom_components.spotcast.spotify.client import Spotify, SpotifyException
+
+CALL_ARGS = ("GET", "me/player/devices", None, {})
+
+
+def unauthorized() -> SpotifyException:
+    """Builds the exception spotipy raises on a 401."""
+    return SpotifyException(401, -1, "url:\n Access token missing")
 
 
 class TestSaveToLibrary(TestCase):
@@ -68,3 +77,71 @@ class TestPlaylistItems(TestCase):
             )
         except AssertionError:
             self.fail()
+
+
+class TestUnauthorizedRetry(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def setUp(self, mock_call: MagicMock):
+        self.mock_call = mock_call
+        self.mock_call.side_effect = [unauthorized(), {"devices": []}]
+
+        self.refresher = MagicMock(return_value="fresh")
+        self.client = Spotify(auth="stale", token_refresher=self.refresher)
+
+        self.result = self.client._internal_call(*CALL_ARGS)
+
+    def test_result_of_the_retry_returned(self):
+        self.assertEqual(self.result, {"devices": []})
+
+    def test_token_refresh_forced(self):
+        self.refresher.assert_called_once_with()
+
+    def test_fresh_token_applied_to_the_client(self):
+        self.assertEqual(self.client._auth, "fresh")
+
+    def test_call_retried_once(self):
+        self.assertEqual(self.mock_call.call_count, 2)
+
+
+class TestUnauthorizedWithoutRefresher(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def test_exception_raised(self, mock_call: MagicMock):
+        mock_call.side_effect = unauthorized()
+        client = Spotify(auth="stale")
+
+        with self.assertRaises(SpotifyException):
+            client._internal_call(*CALL_ARGS)
+
+        self.assertEqual(mock_call.call_count, 1)
+
+
+class TestUnauthorizedWithFailingRefresh(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def test_original_error_raised(self, mock_call: MagicMock):
+        mock_call.side_effect = unauthorized()
+        refresher = MagicMock(side_effect=ConnectionError("no token"))
+        client = Spotify(auth="stale", token_refresher=refresher)
+
+        with self.assertRaises(SpotifyException) as ctx:
+            client._internal_call(*CALL_ARGS)
+
+        self.assertEqual(ctx.exception.http_status, 401)
+        self.assertEqual(mock_call.call_count, 1)
+
+
+class TestOtherErrorNotRetried(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def test_exception_raised_without_retry(self, mock_call: MagicMock):
+        mock_call.side_effect = SpotifyException(404, -1, "url:\n Not found")
+        refresher = MagicMock(return_value="fresh")
+        client = Spotify(auth="valid", token_refresher=refresher)
+
+        with self.assertRaises(SpotifyException):
+            client._internal_call(*CALL_ARGS)
+
+        self.assertEqual(mock_call.call_count, 1)
+        refresher.assert_not_called()


### PR DESCRIPTION
## Problem

A `401` on a token the session still considers valid failed the whole coordinator cycle:

```
HTTP Error for GET to .../v1/me/player/devices returned 401 due to Access token missing
Unexpected error fetching spotcast_01KDG66RTFTZQ75X2XA5QS6YR7 data
```

`async_devices` refreshes both tokens before the call, so an expired token is not the explanation. Spotify answers `No token provided` when the `Authorization` header is absent, and `Missing/invalid/expired access token` when the token is bad (both verified against the live API) - neither matches. The message comes from a Spotify gateway that momentarily lost the auth context, the same family of degraded responses that also had the core `spotify` integration failing on incomplete playback payloads the same day.

## Changes

- `Spotify` (the extended spotipy client) takes an optional `token_refresher` and overrides `_internal_call`: on a `401` it forces a token refresh, re-applies the token, and retries the call exactly once. A `401` means the request never executed, so the retry is safe for the playback writes too. Any other status, or a client built without a refresher (the config flow's throwaway client), behaves as before. If the refresh itself fails, the original `401` is re-raised so callers keep seeing one predictable error.
- `async_ensure_token_valid(force=False)` and `get_token(api, force=False)` so a refresh can bypass the not-yet-expired check. `get_token` already went through `run_coroutine_threadsafe`, which is what the retry needs from the executor thread.
- The new `Spotify rejected the access token for %s` warning gives a usable signal if this ever turns out to be our own token handling after all.

Unrelated bug found while reading the refresh path:

- `DesktopSession.async_refresh_token` returned the raw response, and `self.token = api_response` replaced the stored token wholesale. Spotify may omit `refresh_token` when the current one stays valid, which would leave the session permanently unable to refresh. The response is now merged over the stored token, matching what `PublicSession` gets from Home Assistant's OAuth implementation.

## Tests

751 tests pass; pylint 10.00/10 on `custom_components`. Added four cases for the retry (succeeds, no refresher, refresh fails, non-401 not retried) and one for the retained refresh token.

## Caveat

This makes the symptom recoverable, it does not prove the cause. If Spotify was at fault the retry papers over it; if something on our side really did drop the token, the new warning will say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)