### PR TITLE
Add a consistency test over the translation files

### DIFF
--- a/test/test_translations_consistency.py
+++ b/test/test_translations_consistency.py
@@ -1,0 +1,123 @@
+"""Module to test that the translation files stay in sync.
+
+`strings.json` is the source of truth Home Assistant validates through
+hassfest, and `translations/en.json` must be a copy of it. Every other
+language file must expose exactly the same keys with exactly the same
+`{placeholder}` tokens: Home Assistant falls back to English for a
+missing key, so a typo in a language file degrades silently, and a
+placeholder that was renamed or dropped in translation renders the raw
+token to the user. Nothing else in CI looks at the non-English files,
+so these tests are the only gate.
+"""
+
+from json import loads
+from pathlib import Path
+from re import findall
+from unittest import TestCase
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+INTEGRATION_DIR = REPOSITORY_ROOT / "custom_components" / "spotcast"
+STRINGS_FILE = INTEGRATION_DIR / "strings.json"
+TRANSLATIONS_DIR = INTEGRATION_DIR / "translations"
+REFERENCE_FILE = TRANSLATIONS_DIR / "en.json"
+
+PLACEHOLDER_PATTERN = r"\{[a-zA-Z_][a-zA-Z0-9_]*\}"
+
+
+def read(path: Path) -> dict:
+    """Returns the parsed content of a translation file."""
+    return loads(path.read_text(encoding="utf-8"))
+
+
+def flatten(content: dict, prefix: str = "") -> dict:
+    """Returns the leaf strings of a translation file, keyed by their
+    dotted path."""
+    leaves = {}
+
+    for key, value in content.items():
+        path = f"{prefix}.{key}" if prefix else key
+
+        if isinstance(value, dict):
+            leaves.update(flatten(value, path))
+        else:
+            leaves[path] = value
+
+    return leaves
+
+
+def placeholders(value: str) -> set:
+    """Returns the `{placeholder}` tokens found in a translated
+    string."""
+    return set(findall(PLACEHOLDER_PATTERN, value))
+
+
+class TestTranslationsInSync(TestCase):
+
+    def setUp(self):
+        self.reference = flatten(read(REFERENCE_FILE))
+        self.languages = sorted(
+            path for path in TRANSLATIONS_DIR.glob("*.json")
+            if path != REFERENCE_FILE
+        )
+
+    def test_english_translation_matches_strings(self):
+        """hassfest validates `strings.json`; the English translation
+        is what actually reaches the user. They must not diverge."""
+        self.assertEqual(
+            read(STRINGS_FILE),
+            read(REFERENCE_FILE),
+            "strings.json and translations/en.json must be identical",
+        )
+
+    def test_languages_are_present(self):
+        """Guards the glob itself: an empty list would make every test
+        below pass vacuously."""
+        self.assertTrue(
+            self.languages,
+            f"no language files found in {TRANSLATIONS_DIR}",
+        )
+
+    def test_keys_match_reference(self):
+        for path in self.languages:
+            with self.subTest(language=path.stem):
+                translation = flatten(read(path))
+
+                missing = sorted(set(self.reference) - set(translation))
+                extra = sorted(set(translation) - set(self.reference))
+
+                self.assertFalse(
+                    missing,
+                    f"{path.name} is missing keys: {missing}",
+                )
+                self.assertFalse(
+                    extra,
+                    f"{path.name} has keys absent from en.json: {extra}",
+                )
+
+    def test_placeholders_match_reference(self):
+        for path in self.languages:
+            with self.subTest(language=path.stem):
+                translation = flatten(read(path))
+
+                for key, expected in self.reference.items():
+                    if key not in translation:
+                        continue
+
+                    self.assertEqual(
+                        placeholders(translation[key]),
+                        placeholders(expected),
+                        f"{path.name} placeholder mismatch at `{key}`",
+                    )
+
+    def test_no_empty_translations(self):
+        for path in self.languages:
+            with self.subTest(language=path.stem):
+                blank = sorted(
+                    key for key, value in flatten(read(path)).items()
+                    if not value.strip()
+                )
+
+                self.assertFalse(
+                    blank,
+                    f"{path.name} has empty translations: {blank}",
+                )


### PR DESCRIPTION
## Description

Follow-up to #63, which added the first non-English language file since `fr.json`.

Nothing in CI currently validates the non-English translation files. hassfest checks `strings.json` and the English side, and stops there. That means:

- a missing key falls back to English silently, so the language looks complete while parts of it are not;
- a `{placeholder}` renamed or dropped during translation renders the raw token to the user;
- `strings.json` and `translations/en.json` are maintained as byte-identical copies by hand, with nothing enforcing it.

`test/test_translations_consistency.py` closes all three. It asserts that `strings.json` and `translations/en.json` parse to the same content, and for every other `translations/*.json`: identical leaf-key sets, identical placeholder tokens per key, and no blank strings. New languages are picked up automatically through a glob, with a guard test so an empty glob cannot make the rest pass vacuously.

Paths are resolved from `__file__` rather than by importing the integration, so the test needs no `homeassistant` import and runs in milliseconds.

It follows the shape of the existing `test/test_options_consistency.py`, which guards the same class of silent drift on the options side.

Scope note: this catches structural drift, not translation quality. The five content errors corrected in #63 (a leftover English fragment, a typo, a mistranslation, two casing errors) were all key-parity-clean and no automated check would have caught them.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code where necessary
- [x] I have added tests that are covering all code branches
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
