### PR TITLE
Release v6.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.5.4
+current_version = 6.6.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[^\d]*)(?P<build>\d+))?
 serialize = 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This repository is the continuation of the original [fondberg/spotcast](https://github.com/fondberg/spotcast) project. For the history of releases prior to v6, see the [original project's releases](https://github.com/fondberg/spotcast/releases). Releases v6.3.0 through v6.5.2 are documented in the [GitHub release notes](https://github.com/Mincka/spotcast/releases).
 
+## v6.6.0 (2026-07-25)
+
+### Changes
+
+- The integration is now available in German. The configuration flow, the options form and all ten service definitions are translated, bringing the shipped languages to English, French and German (thanks @vlntnwbr, [#63](https://github.com/Mincka/spotcast/pull/63)).
+
+### Project changes
+
+- Translation files are covered by a consistency test. `strings.json` and `translations/en.json` must stay identical, and every other language file must expose the same keys with the same `{placeholder}` tokens and no blank strings. New languages are picked up automatically, so a missing key can no longer fall back to English unnoticed ([#64](https://github.com/Mincka/spotcast/pull/64)).
+
 ## v6.5.4 (2026-07-21)
 
 ### Fixes

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import DEFAULT_OPTIONS
 from .spotify import SpotifyAccount
 from .coordinator import SpotcastCoordinator
 
-__version__ = "6.5.4"
+__version__ = "6.6.0"
 
 
 LOGGER = getLogger(__name__)

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -22,5 +22,5 @@
         "spotipy>=2.26.0",
         "RapidFuzz>=3.14.5"
     ],
-    "version": "6.5.4"
+    "version": "6.6.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotcast"
-version = "6.5.4"
+version = "6.6.0"
 description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for Chromecast as well as Spotify Connect devices."
 readme = "README.md"
 requires-python = ">=3.14.2"

--- a/uv.lock
+++ b/uv.lock
@@ -2132,7 +2132,7 @@ wheels = [
 
 [[package]]
 name = "spotcast"
-version = "6.5.4"
+version = "6.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "atomicwrites-homeassistant" },


### PR DESCRIPTION
## Description

Version bump to **6.6.0** across `manifest.json`, `custom_components/spotcast/__init__.py`, `pyproject.toml`, `.bumpversion.cfg` and the `spotcast` entry in `uv.lock`, plus the changelog section.

Minor rather than patch: this release ships a new user-facing language, which is additive functionality rather than a fix.

### Contents

- **German translation** (#63, thanks @vlntnwbr) - configuration flow, options form and all ten service definitions. Shipped languages are now English, French and German. Reviewed for key parity against `en.json` (135 leaf keys, matching placeholders and ordering); five content corrections were pushed to the branch before merge.
- **Translation consistency test** (#64) - guards `strings.json` / `translations/en.json` equality and key, placeholder and non-blank parity for every other language file.

`scripts/connect_desktop_oauth.py` was removed in #62 after v6.5.4; it was an unreferenced helper with no user-visible effect, so it gets no changelog entry.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
