### PR TITLE
Report a refused cast instead of hanging on it

### DIFF
--- a/custom_components/spotcast/chromecast/spotify_controller.py
+++ b/custom_components/spotcast/chromecast/spotify_controller.py
@@ -29,8 +29,14 @@ LOGGER = getLogger(__name__)
 # a `getInfo` request reliably. Single devices do not need this.
 GROUP_LAUNCH_DELAY = 3.0
 
+# `Chromecast.wait()` has no timeout of its own and retries forever, so an
+# unreachable device would block the caller rather than fail it.
+CONNECT_TIMEOUT = 20.0
 
-class SpotifyController(BaseController):
+
+class SpotifyController(  # pylint: disable=too-many-instance-attributes
+    BaseController
+):
     """A Chromcast controller for interacting with Spotify
 
     Attributes:
@@ -96,6 +102,10 @@ class SpotifyController(BaseController):
         self.activated_device_id: str = None
         self.credential_error = False
 
+        # What the device said when it refused, for the waiting thread to
+        # raise -- the handlers cannot raise it themselves.
+        self.launch_error: str = None
+
     def _send_message_callback(self, *_):
         """Call back method to send a message after the launch method"""
         if self.current_device is not None and self.current_device.is_group:
@@ -115,6 +125,8 @@ class SpotifyController(BaseController):
         self.is_launched = False
         self.current_device = device
         self.activated_device_id = None
+        self.credential_error = False
+        self.launch_error = None
 
         self._current_message = {
             "type": self.TYPE_GET_INFO,
@@ -126,12 +138,12 @@ class SpotifyController(BaseController):
         }
 
         LOGGER.debug("Waiting for `%s` to be ready", device.name)
-        device.wait()
+        self._wait_for_connection(device)
 
         LOGGER.debug("Starting Spotify on `%s`", device.name)
         device.start_app(self.APP_ID)
         LOGGER.debug("Waiting for `%s` to be available", device.name)
-        device.wait()
+        self._wait_for_connection(device)
 
         self.waiting.clear()
 
@@ -149,6 +161,14 @@ class SpotifyController(BaseController):
                 )
                 return
 
+            # Raised here because the handler that detected it runs on the
+            # socket client's thread, where an exception is logged and dropped.
+            if self.credential_error:
+                raise AppLaunchError(
+                    self.launch_error
+                    or "Spotify refused the credentials for this device"
+                )
+
             if max_attempts is not None and counter >= max_attempts:
                 raise AppLaunchError(
                     "Timeout when waiting for status response from Spotify app"
@@ -160,6 +180,18 @@ class SpotifyController(BaseController):
             )
             self.waiting.wait(1)
             counter += 1
+
+    def _wait_for_connection(self, device: Chromecast):
+        """Waits for the device to be reachable, bounded by CONNECT_TIMEOUT"""
+        device.wait(timeout=CONNECT_TIMEOUT)
+
+        socket_client = getattr(device, "socket_client", None)
+        if socket_client is not None and not socket_client.is_connected:
+            raise AppLaunchError(
+                f"Could not connect to `{device.name}` within "
+                f"{CONNECT_TIMEOUT:.0f}s. The device may be powered down or "
+                "unreachable on the network."
+            )
 
     def stop_app(self, device: Chromecast):
         """Stops the Spotify app on the device"""
@@ -252,21 +284,45 @@ class SpotifyController(BaseController):
 
         return True
 
-    def _add_user_error_handler(self, *_, **__) -> bool:
+    def _add_user_error_handler(
+        self, _message: CastMessage, data: dict
+    ) -> bool:
         """Handler for the add user error message"""
         self.current_device = None
         self.credential_error = True
+        self.launch_error = self._describe(
+            "Spotify refused the credentials for this device", data
+        )
+        LOGGER.error("%s", self.launch_error)
         self.waiting.set()
 
-        raise AppLaunchError("Credentials error. Laucnhgin spotify failed")
+        return True
 
-    def _transfer_error_handler(self, *_, **__) -> bool:
+    def _transfer_error_handler(
+        self, _message: CastMessage, data: dict
+    ) -> bool:
         """Handler for the transfer error message"""
         self.current_device = None
         self.credential_error = True
+        self.launch_error = self._describe(
+            "Spotify refused to transfer playback to this device", data
+        )
+        LOGGER.error("%s", self.launch_error)
         self.waiting.set()
 
-        raise AppLaunchError("Device took too much time to start playback")
+        return True
+
+    @staticmethod
+    def _describe(summary: str, data: dict) -> str:
+        """Adds the device's own account of the refusal to a summary"""
+        payload = (data or {}).get("payload") or {}
+        detail = ", ".join(
+            f"{key}={payload[key]}"
+            for key in ("status", "statusString", "spotifyError", "reason")
+            if key in payload
+        )
+
+        return f"{summary} ({detail})" if detail else summary
 
     def _transfer_success_handler(self, *_, **__) -> bool:
         """Handles the transfer success message"""

--- a/test/chromecast/spotify_controller/test_add_user_error_handler.py
+++ b/test/chromecast/spotify_controller/test_add_user_error_handler.py
@@ -21,13 +21,18 @@ class TestAddUserErrorHandling(TestCase):
         mock_account = MagicMock(spec=SpotifyAccount)
         self.controller = SpotifyController(mock_account)
 
-        try:
-            self.controller._add_user_error_handler(
-                MagicMock(spec=CastMessage),
-                {}
-            )
-        except AppLaunchError:
-            pass
+        # The handler records the refusal rather than raising it, since it
+        # runs on a thread where a raise would be logged and dropped.
+        self.controller._add_user_error_handler(
+            MagicMock(spec=CastMessage),
+            {
+                "payload": {
+                    "status": 108,
+                    "statusString": "ERROR-CANNOT-LOAD",
+                    "spotifyError": 409,
+                }
+            }
+        )
 
     def test_device_removed(self):
         self.assertIsNone(self.controller.current_device)
@@ -40,3 +45,7 @@ class TestAddUserErrorHandling(TestCase):
 
     def test_credentials_error_set(self):
         self.assertTrue(self.controller.credential_error)
+
+    def test_records_what_the_device_said(self):
+        self.assertIn("ERROR-CANNOT-LOAD", self.controller.launch_error)
+        self.assertIn("409", self.controller.launch_error)

--- a/test/chromecast/spotify_controller/test_launch_app.py
+++ b/test/chromecast/spotify_controller/test_launch_app.py
@@ -93,3 +93,40 @@ class TestAppFailLaunch(TestCase):
 
     def set_is_launched(self, *_, **__):
         self.controller.is_launched = True
+
+
+class TestCredentialRefusal(TestCase):
+    """A refusal reported by the device must reach the caller"""
+
+    @patch.object(SpotifyController, "launch")
+    def test_credential_error_is_raised_to_the_caller(self, mock_launch: MagicMock):
+        controller = SpotifyController(MagicMock(spec=SpotifyAccount))
+
+        def refuse(*_, **__):
+            controller._add_user_error_handler(
+                MagicMock(),
+                {"payload": {"statusString": "ERROR-CANNOT-LOAD",
+                             "spotifyError": 409}},
+            )
+
+        mock_launch.side_effect = refuse
+
+        with self.assertRaises(AppLaunchError) as caught:
+            controller.launch_app(MagicMock(spec=Chromecast), max_attempts=10)
+
+        self.assertIn("ERROR-CANNOT-LOAD", str(caught.exception))
+
+    @patch.object(SpotifyController, "launch")
+    def test_an_unreachable_device_does_not_block(self, mock_launch: MagicMock):
+        """An unreachable device fails the call rather than blocking it"""
+        controller = SpotifyController(MagicMock(spec=SpotifyAccount))
+
+        device = MagicMock(spec=Chromecast)
+        device.socket_client = MagicMock()
+        device.socket_client.is_connected = False
+
+        with self.assertRaises(AppLaunchError) as caught:
+            controller.launch_app(device, max_attempts=2)
+
+        self.assertIn("Could not connect", str(caught.exception))
+        mock_launch.assert_not_called()

--- a/test/chromecast/spotify_controller/test_transfer_error_handler.py
+++ b/test/chromecast/spotify_controller/test_transfer_error_handler.py
@@ -21,13 +21,18 @@ class TestTransferErrorHandling(TestCase):
         mock_account = MagicMock(spec=SpotifyAccount)
         self.controller = SpotifyController(mock_account)
 
-        try:
-            self.controller._transfer_error_handler(
-                MagicMock(spec=CastMessage),
-                {}
-            )
-        except AppLaunchError:
-            pass
+        # The handler records the refusal rather than raising it, since it
+        # runs on a thread where a raise would be logged and dropped.
+        self.controller._transfer_error_handler(
+            MagicMock(spec=CastMessage),
+            {
+                "payload": {
+                    "status": 108,
+                    "statusString": "ERROR-CANNOT-LOAD",
+                    "spotifyError": 409,
+                }
+            }
+        )
 
     def test_device_removed(self):
         self.assertIsNone(self.controller.current_device)
@@ -40,3 +45,7 @@ class TestTransferErrorHandling(TestCase):
 
     def test_credentials_error_set(self):
         self.assertTrue(self.controller.credential_error)
+
+    def test_records_what_the_device_said(self):
+        self.assertIn("ERROR-CANNOT-LOAD", self.controller.launch_error)
+        self.assertIn("409", self.controller.launch_error)


### PR DESCRIPTION
## Description

A cold cast to a Chromecast can hang indefinitely. Home Assistant does not answer a service call until the service returns, so the caller waits with nothing to time out against. observed a `spotcast.play` call still unanswered after 150 seconds while the target device sat untouched, and the same device gave no useful error on the attempts that did return.

Four separate defects in `chromecast/spotify_controller.py` combine to produce that, and each is a problem on its own:

1. **`launch_app` waits on `Chromecast.wait()` twice with no timeout.** When the socket client cannot reach the device it retries forever, so an unreachable device blocks the service call rather than failing it. **This is the hang.** The waits are now bounded by `CONNECT_TIMEOUT` and report what happened.

2. **The wait loop only ever checks `is_launched`.** A device that had *already replied* refusing the credentials was polled over until `max_attempts` ran out, then reported as `"Timeout when waiting for status response from Spotify app"` -- a wait for an answer that had arrived and said no. The loop now also checks `credential_error`.

3. **`_add_user_error_handler` and `_transfer_error_handler` raise.** They run on the socket client's message-routing thread, where the exception is logged as `"Error doing job: AppLaunchError exception in shielded future"` and discarded, so it never reaches the caller. They now record the failure and let the waiting thread raise it. 

4. **Both handlers took `*_, **__` and dropped the payload**, which is the only account of why Spotify refused: `status`, `statusString` and `spotifyError`. A refusal is now reported as `"Spotify refused the credentials for this device (status=108, statusString=ERROR-CANNOT-LOAD, spotifyError=409)"` rather than a fixed string -- the difference between knowing to re-authorize and guessing.

No existing issue to link; happy to open one first if you would prefer that.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

No public action, entity or WebSocket endpoint changes shape, so nothing under `docs/` or the `README.md` tables needed updating. The externally visible change is that a failure now arrives as an `AppLaunchError` carrying the device's own words, where it previously arrived as a timeout or not at all.
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code where necessary
- [x] I have added tests that are covering all code branches
- [x] New and existing unit tests pass locally with my changes

## Additional Information

### Verification

**Full suite: 760 tests, OK** (Python 3.14).
**`pylint --fail-under 9 custom_components`: 9.99/10**, with no messages against `spotify_controller.py`. The one added `# pylint: disable=too-many-instance-attributes` follows the existing convention in `media_player/device_manager.py` and `spotify/account/__init__.py`; recording the refusal needs an eighth attribute. **Coverage of `spotify_controller.py`: 100%** (125 statements, 10 branches, none missed).

The new tests were checked against unpatched `main` to confirm they actually catch the bugs rather than merely passing:

| Test | vs. `main` | Catches |
| --- | --- | --- |
| `test_an_unreachable_device_does_not_block` | FAIL | the untimed `wait()` hang (1) |
| `test_credential_error_is_raised_to_the_caller` | FAIL | refusal polled over until timeout (2) |
| 8 error-handler tests | ERROR in `setUp` | the handlers raise (3) |

The handler tests erroring rather than failing is itself the defect: against `main`, `setUp` cannot even construct the scenario because calling the handler throws.

### Live result
Against a real Chromecast Audio that had been failing repeatedly, the same cast that had previously not answered at all returned in **9.5 seconds** with playback started. 

**One caveat, stated plainly:** deploying the patch required restarting Home Assistant, which would also clear a wedged `pychromecast` socket. So I cannot fully separate "the patch fixed it" from "the restart fixed it" on that one observation. The four defects above are each demonstrable from the code and are pinned by the tests independently of that run; defect 4 in particular is what produced the `status=108 / ERROR-CANNOT-LOAD / spotifyError=409` values quoted above, which were previously discarded and are how the account-level refusal was identified at all.

### Incidental

Fixed the typo `"Credentials error. Laucnhgin spotify failed"` while rewriting that message.