### PR TITLE
Pause all accounts on a Spotify rate limit instead of sleeping in the executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This repository is the continuation of the original [fondberg/spotcast](https://github.com/fondberg/spotcast) project. For the history of releases prior to v6, see the [original project's releases](https://github.com/fondberg/spotcast/releases). Releases v6.3.0 through v6.5.2 are documented in the [GitHub release notes](https://github.com/Mincka/spotcast/releases).
 
+## Unreleased
+
+### Fixes
+
+- A Spotify rate limit (`429`) no longer blocks Home Assistant for hours. spotipy retried a `429` by sleeping the full `Retry-After` (up to 6 hours, up to 3 times) inside a Home Assistant worker thread, once per account and once per action call, so a rate limit left coordinator refreshes and `play_media` calls hanging for hours and every waking thread immediately re-knocked on a door that had already said no. Spotcast now disables spotipy's `429` retry, reads `Retry-After` once and pauses every account sharing the client id until the window expires: refreshes fail fast with "Spotify rate limit active ... paused for N s (until HH:MM:SS)", action calls return "Spotify is rate limiting this client id. Try again in N s", system health shows a `Rate Limit` row, and everything resumes on its own ([#68](https://github.com/Mincka/spotcast/issues/68)).
+
 ## v6.6.0 (2026-07-25)
 
 ### Changes

--- a/custom_components/spotcast/coordinator.py
+++ b/custom_components/spotcast/coordinator.py
@@ -15,7 +15,6 @@ Constants:
 from asyncio import exceptions as asyncio_errors
 from datetime import timedelta
 from logging import getLogger
-from re import compile as re_compile
 
 from aiohttp.client_exceptions import ClientResponseError
 from homeassistant.core import HomeAssistant
@@ -29,6 +28,8 @@ from spotipy import SpotifyException
 
 from custom_components.spotcast.const import DOMAIN
 from custom_components.spotcast.spotify import SpotifyAccount
+from custom_components.spotcast.spotify.client import SERVER_ERROR_PATTERN
+from custom_components.spotcast.spotify.exceptions import RateLimitedError
 from custom_components.spotcast.sessions.exceptions import TokenError
 from custom_components.spotcast.sessions.retry_supervisor import (
     RetrySupervisor,
@@ -45,8 +46,6 @@ POTENTIAL_ERRORS = (
     RetrySupervisor.SUPERVISED_EXCEPTIONS + ENTITY_SPECIFIC_ERRORS
 )
 UPDATE_ERRORS = POTENTIAL_ERRORS + (SpotifyException, ClientResponseError)
-
-SERVER_ERROR_PATTERN = re_compile(r"too many 5\d\d error responses")
 
 
 class SpotcastCoordinator(DataUpdateCoordinator[dict]):
@@ -133,7 +132,19 @@ class SpotcastCoordinator(DataUpdateCoordinator[dict]):
         exhausted, even when the retried responses were 5xx server
         errors. Report those as a Spotify outage instead of echoing a
         misleading rate-limit status (see spotipy-dev/spotipy#805).
+
+        A rate limit pauses every account until the `Retry-After`
+        window expires; the refresh fails fast without a network call
+        and the message says when it resumes.
         """
+        if isinstance(exc, RateLimitedError):
+            return (
+                "Spotify rate limit active for this client id. Refresh "
+                f"of entry `{self.account.entry_id}` paused for "
+                f"{exc.seconds_remaining} s (until "
+                f"{exc.resume_time})"
+            )
+
         if (
             isinstance(exc, SpotifyException)
             and exc.http_status == 429

--- a/custom_components/spotcast/services/service_handler.py
+++ b/custom_components/spotcast/services/service_handler.py
@@ -8,6 +8,7 @@ Classes:
 from logging import getLogger
 
 from homeassistant.core import ServiceCall, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.spotcast.services.exceptions import (
     UnknownServiceError,
@@ -15,6 +16,7 @@ from custom_components.spotcast.services.exceptions import (
 
 from custom_components.spotcast.services.const import SERVICE_HANDLERS
 from custom_components.spotcast.coordinator import POTENTIAL_ERRORS
+from custom_components.spotcast.spotify.exceptions import RateLimitedError
 
 LOGGER = getLogger(__name__)
 
@@ -59,5 +61,10 @@ class ServiceHandler:  # pylint: disable=too-few-public-methods
 
         try:
             await handler(self.hass, call)
+        except RateLimitedError as exc:
+            raise HomeAssistantError(
+                "Spotify is rate limiting this client id. Try again in "
+                f"{exc.seconds_remaining} s (after {exc.resume_time})"
+            ) from exc
         except POTENTIAL_ERRORS as exc:
             LOGGER.error(exc)

--- a/custom_components/spotcast/spotify/account/playback.py
+++ b/custom_components/spotcast/spotify/account/playback.py
@@ -10,7 +10,10 @@ from time import time
 
 from spotipy import SpotifyException
 
-from custom_components.spotcast.spotify.exceptions import PlaybackError
+from custom_components.spotcast.spotify.exceptions import (
+    PlaybackError,
+    RateLimitedError,
+)
 
 LOGGER = getLogger(__name__)
 
@@ -195,6 +198,8 @@ class PlaybackMixin:
                     True,
                 )
                 return
+            except RateLimitedError:
+                raise
             except SpotifyException as exc:
                 raise PlaybackError(exc.msg) from exc
 
@@ -226,31 +231,56 @@ class PlaybackMixin:
 
         try:
             await self.hass.async_add_executor_job(*start_args)
+        except RateLimitedError:
+            raise
         except SpotifyException as exc:
             if exc.http_status != 404:
                 raise PlaybackError(exc.msg) from exc
 
-            # A Spotify Connect device that just came online (e.g. a
-            # librespot device) may not be registered yet when we issue
-            # the play command, so Spotify answers 404 "Device not found".
-            # Wait for it to appear and retry once before giving up,
-            # instead of surfacing an error the user cannot act on.
-            LOGGER.info(
-                "Device `%s` not found on first play attempt; waiting for "
-                "it to become available",
-                device_id,
-            )
+            await self._async_retry_when_device_appears(start_args, device_id)
 
-            try:
-                await self.async_wait_for_device(device_id)
-                await self.hass.async_add_executor_job(*start_args)
-            except TimeoutError as timeout_exc:
-                raise PlaybackError(
-                    f"Device `{device_id}` is not available on Spotify "
-                    "Connect."
-                ) from timeout_exc
-            except SpotifyException as retry_exc:
-                raise PlaybackError(retry_exc.msg) from retry_exc
+    async def _async_retry_when_device_appears(
+        self,
+        start_args: tuple,
+        device_id: str,
+    ):
+        """Retries a playback start once the device is registered.
+
+        A Spotify Connect device that just came online (e.g. a
+        librespot device) may not be registered yet when we issue the
+        play command, so Spotify answers 404 "Device not found". Wait
+        for it to appear and retry once before giving up, instead of
+        surfacing an error the user cannot act on.
+
+        Args:
+            - start_args(tuple): the executor job arguments of the
+                playback start
+            - device_id(str): the id of the device to wait for
+
+        Raises:
+            - PlaybackError: raised when the device never shows up or
+                the retry fails
+            - RateLimitedError: raised when the retry hits the rate
+                limit, untouched so it surfaces with its resume time
+        """
+        LOGGER.info(
+            "Device `%s` not found on first play attempt; waiting for "
+            "it to become available",
+            device_id,
+        )
+
+        try:
+            await self.async_wait_for_device(device_id)
+            await self.hass.async_add_executor_job(*start_args)
+        except TimeoutError as timeout_exc:
+            raise PlaybackError(
+                f"Device `{device_id}` is not available on Spotify "
+                "Connect."
+            ) from timeout_exc
+        except RateLimitedError:
+            raise
+        except SpotifyException as retry_exc:
+            raise PlaybackError(retry_exc.msg) from retry_exc
 
     async def async_shuffle(
         self,
@@ -337,6 +367,8 @@ class PlaybackMixin:
                 uri,
                 device_id,
             )
+        except RateLimitedError:
+            raise
         except SpotifyException as exc:
             raise PlaybackError(
                 f"Could not add `{uri}` to device `{device_id}`"

--- a/custom_components/spotcast/spotify/client.py
+++ b/custom_components/spotcast/spotify/client.py
@@ -9,8 +9,11 @@ from logging import getLogger
 from re import compile as re_compile
 from typing import Any
 
+from requests import Session
+from requests.adapters import HTTPAdapter
 from spotipy import Spotify as SpotipyClient
 from spotipy.exceptions import SpotifyException
+from urllib3.util.retry import Retry
 
 from custom_components.spotcast.spotify.exceptions import RateLimitedError
 from custom_components.spotcast.spotify.rate_limit import (
@@ -23,7 +26,8 @@ LOGGER = getLogger(__name__)
 # spotipy retries 429 responses by sleeping the full `Retry-After`
 # inside the calling (executor) thread, up to 3 times, which can block
 # a Home Assistant worker for hours. Rate limits are handled by the
-# shared guard instead; only server errors are left to spotipy.
+# shared guard instead; only server errors are left to the retry
+# adapter, with a short exponential backoff.
 SERVER_ERROR_RETRY_CODES = (500, 502, 503, 504)
 
 # spotipy hard-codes http status 429 when its retries are exhausted,
@@ -75,6 +79,31 @@ class Spotify(SpotipyClient):
         super().__init__(*args, **kwargs)
         self._token_refresher = token_refresher
         self._rate_limit_guard = rate_limit_guard or RATE_LIMIT_GUARD
+
+    def _build_session(self):
+        """Builds the requests session with a retry adapter that never
+        sleeps on a `Retry-After` header.
+
+        Removing 429 from `status_forcelist` is not enough: urllib3
+        also retries any 429/503 that carries a `Retry-After` header
+        when `respect_retry_after_header` is set (the default), and
+        spotipy's own session builder gives no way to turn it off.
+        """
+        self._session = Session()
+        retry = Retry(
+            total=self.retries,
+            connect=None,
+            read=False,
+            allowed_methods=frozenset(["GET", "POST", "PUT", "DELETE"]),
+            status=self.status_retries,
+            backoff_factor=self.backoff_factor,
+            status_forcelist=self.status_forcelist,
+            respect_retry_after_header=False,
+        )
+
+        adapter = HTTPAdapter(max_retries=retry)
+        self._session.mount("http://", adapter)
+        self._session.mount("https://", adapter)
 
     def _internal_call(
         self,

--- a/custom_components/spotcast/spotify/client.py
+++ b/custom_components/spotcast/spotify/client.py
@@ -6,12 +6,39 @@ Classes:
 
 from collections.abc import Callable
 from logging import getLogger
+from re import compile as re_compile
 from typing import Any
 
 from spotipy import Spotify as SpotipyClient
 from spotipy.exceptions import SpotifyException
 
+from custom_components.spotcast.spotify.exceptions import RateLimitedError
+from custom_components.spotcast.spotify.rate_limit import (
+    RATE_LIMIT_GUARD,
+    RateLimitGuard,
+)
+
 LOGGER = getLogger(__name__)
+
+# spotipy retries 429 responses by sleeping the full `Retry-After`
+# inside the calling (executor) thread, up to 3 times, which can block
+# a Home Assistant worker for hours. Rate limits are handled by the
+# shared guard instead; only server errors are left to spotipy.
+SERVER_ERROR_RETRY_CODES = (500, 502, 503, 504)
+
+# spotipy hard-codes http status 429 when its retries are exhausted,
+# even when the retried responses were 5xx server errors (see
+# spotipy-dev/spotipy#805). The real status is in the reason.
+SERVER_ERROR_PATTERN = re_compile(r"too many 5\d\d error responses")
+
+
+def is_rate_limit(exc: SpotifyException) -> bool:
+    """Returns True if the exception is a genuine rate limit response,
+    as opposed to spotipy's fake 429 for exhausted 5xx retries."""
+    return exc.http_status == 429 and not (
+        exc.reason is not None
+        and SERVER_ERROR_PATTERN.search(str(exc.reason))
+    )
 
 
 class Spotify(SpotipyClient):
@@ -21,13 +48,17 @@ class Spotify(SpotipyClient):
     created after 2026-02-11 (older ids are grandfathered).
 
     Also retries once with a freshly refreshed token when the API
-    rejects a token the session still considers valid.
+    rejects a token the session still considers valid, and honours the
+    integration wide rate limit guard: a 429 pauses every client
+    sharing the guard until the `Retry-After` window expires, without
+    blocking the executor thread.
     """
 
     def __init__(
         self,
         *args,
         token_refresher: Callable[[], str] | None = None,
+        rate_limit_guard: RateLimitGuard | None = None,
         **kwargs,
     ):
         """Constructor of the extended spotipy client.
@@ -36,9 +67,14 @@ class Spotify(SpotipyClient):
             token_refresher(Callable, optional): Called from the
                 executor thread to obtain a freshly refreshed access
                 token after a 401. Retries are disabled when omitted.
+            rate_limit_guard(RateLimitGuard, optional): the shared
+                rate limit state. Defaults to the integration wide
+                guard.
         """
+        kwargs.setdefault("status_forcelist", SERVER_ERROR_RETRY_CODES)
         super().__init__(*args, **kwargs)
         self._token_refresher = token_refresher
+        self._rate_limit_guard = rate_limit_guard or RATE_LIMIT_GUARD
 
     def _internal_call(
         self,
@@ -53,10 +89,22 @@ class Spotify(SpotipyClient):
         refreshes it before every call. Spotify still occasionally
         rejects a valid token, in which case a forced refresh recovers
         instead of surfacing the failure to the user.
+
+        Raises:
+            - RateLimitedError: raised without any network call while
+                the shared rate limit is active, or after a 429
+                response, which registers the new window.
         """
+        self._rate_limit_guard.check()
+
         try:
             return super()._internal_call(method, url, payload, params)
+        except RateLimitedError:
+            raise
         except SpotifyException as exc:
+            if is_rate_limit(exc):
+                raise self._rate_limited(exc, url) from exc
+
             if exc.http_status != 401 or self._token_refresher is None:
                 raise
 
@@ -76,7 +124,26 @@ class Spotify(SpotipyClient):
 
             self.set_auth(token)
 
-            return super()._internal_call(method, url, payload, params)
+            try:
+                return super()._internal_call(method, url, payload, params)
+            except SpotifyException as retry_exc:
+                if is_rate_limit(retry_exc):
+                    raise self._rate_limited(retry_exc, url) from retry_exc
+                raise
+
+    def _rate_limited(
+        self,
+        exc: SpotifyException,
+        url: str,
+    ) -> RateLimitedError:
+        """Registers a 429 with the shared guard and builds the error
+        raised in its place. A missing `Retry-After` falls back to the
+        guard's default window.
+        """
+        headers = exc.headers or {}
+        retry_at = self._rate_limit_guard.register(headers.get("Retry-After"))
+
+        return RateLimitedError(retry_at, url)
 
     def save_to_library(self, uris: list[str]) -> dict:
         """Saves a list of Spotify URIs to the user's library.

--- a/custom_components/spotcast/spotify/exceptions.py
+++ b/custom_components/spotcast/spotify/exceptions.py
@@ -8,9 +8,14 @@ Classes:
     - InvalidFilterError
     - InvalidTagsError
     - InvalidItemTypeError
+    - RateLimitedError
 """
 
+from datetime import datetime
+from time import time
+
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from spotipy.exceptions import SpotifyException
 
 from custom_components.spotcast.exceptions import TokenError
 
@@ -22,6 +27,7 @@ __all__ = [
     "InvalidFilterError",
     "InvalidTagsError",
     "InvalidItemTypeError",
+    "RateLimitedError",
 ]
 
 
@@ -47,3 +53,43 @@ class InvalidTagsError(SearchQueryError):
 
 class InvalidItemTypeError(SearchQueryError):
     """Raised when a search query is built with an invalid item type"""
+
+
+class RateLimitedError(SpotifyException):
+    """Raised when a Spotify API call is skipped or rejected because
+    the client id is currently rate limited.
+
+    Subclass of `SpotifyException` (http status 429) so the existing
+    error handling of the api callers keeps working.
+
+    Attributes:
+        - retry_at(float): epoch timestamp when calls may resume
+    """
+
+    def __init__(self, retry_at: float, url: str | None = None):
+        """Raised when a Spotify API call is skipped or rejected because
+        the client id is currently rate limited.
+
+        Args:
+            - retry_at(float): epoch timestamp when calls may resume
+            - url(str, optional): the url of the skipped call
+        """
+        self.retry_at = retry_at
+
+        super().__init__(
+            429,
+            -1,
+            f"{url or 'Spotify API'}: rate limited until "
+            f"{self.resume_time}",
+            reason="rate limited",
+        )
+
+    @property
+    def resume_time(self) -> str:
+        """Returns the local time at which calls may resume."""
+        return datetime.fromtimestamp(self.retry_at).strftime("%H:%M:%S")
+
+    @property
+    def seconds_remaining(self) -> int:
+        """Returns the number of seconds until calls may resume."""
+        return max(0, int(self.retry_at - time()) + 1)

--- a/custom_components/spotcast/spotify/rate_limit.py
+++ b/custom_components/spotcast/spotify/rate_limit.py
@@ -1,0 +1,147 @@
+"""Integration wide backoff for the Spotify Web API rate limit.
+
+Spotify enforces its rate limit per client id, not per account. Every
+account configured in spotcast shares the same client id, so a 429
+received by one account applies to all of them. The guard keeps a
+single `retry_at` timestamp that every spotipy client consults before
+sending a request, so the other accounts stop hammering the API (and
+extending the penalty) until the window expires.
+
+Classes:
+    - RateLimitGuard
+
+Constants:
+    - DEFAULT_RETRY_AFTER(int): fallback window, in seconds, when the
+        429 carries no usable `Retry-After` header
+    - RATE_LIMIT_GUARD(RateLimitGuard): the shared guard instance
+"""
+
+from datetime import datetime
+from logging import getLogger, DEBUG, WARNING
+from threading import Lock
+from time import time
+
+from custom_components.spotcast.spotify.exceptions import RateLimitedError
+
+LOGGER = getLogger(__name__)
+
+DEFAULT_RETRY_AFTER = 30
+
+
+class RateLimitGuard:
+    """Shared state for an active Spotify rate limit.
+
+    Thread safe: spotipy calls run in Home Assistant executor threads.
+
+    Properties:
+        - retry_at(float): epoch timestamp when calls may resume. 0
+            when no rate limit is active
+        - is_limited(bool): True while a rate limit is active
+        - seconds_remaining(int): seconds until the limit expires
+
+    Methods:
+        - register
+        - check
+        - clear
+    """
+
+    def __init__(self):
+        """Shared state for an active Spotify rate limit."""
+        self._lock = Lock()
+        self._retry_at = 0.0
+        self._announced = False
+
+    @property
+    def retry_at(self) -> float:
+        """Returns the epoch timestamp when calls may resume."""
+        return self._retry_at
+
+    @property
+    def is_limited(self) -> bool:
+        """Returns True while a rate limit is active."""
+        return time() < self._retry_at
+
+    @property
+    def seconds_remaining(self) -> int:
+        """Returns the number of seconds until the limit expires."""
+        return max(0, int(self._retry_at - time()) + 1)
+
+    @property
+    def resume_time(self) -> str:
+        """Returns the local time at which calls resume, for messages."""
+        return datetime.fromtimestamp(self._retry_at).strftime("%H:%M:%S")
+
+    def register(self, retry_after: str | int | None) -> float:
+        """Records a 429 received from Spotify.
+
+        Args:
+            - retry_after(str | int | None): the value of the
+                `Retry-After` header of the 429 response, in seconds.
+                Falls back to `DEFAULT_RETRY_AFTER` when missing or
+                not a number.
+
+        Returns:
+            - float: the epoch timestamp when calls may resume
+        """
+        seconds = self._parse_retry_after(retry_after)
+
+        with self._lock:
+            retry_at = time() + seconds
+
+            # a longer window already registered wins: the api does
+            # not shorten a penalty because we asked again
+            if retry_at > self._retry_at:
+                self._retry_at = retry_at
+
+            level = DEBUG if self._announced else WARNING
+            self._announced = True
+
+        LOGGER.log(
+            level,
+            "Spotify rate limit reached for this client id. Pausing all "
+            "Spotify API calls for %d s (until %s)",
+            self.seconds_remaining,
+            self.resume_time,
+        )
+
+        return self._retry_at
+
+    def check(self):
+        """Raises if a rate limit is currently active.
+
+        Raises:
+            - RateLimitedError: raised while the rate limit is active
+        """
+        with self._lock:
+            if time() < self._retry_at:
+                raise RateLimitedError(self._retry_at)
+
+            # the window expired: the next 429 is a new event worth a
+            # warning again
+            self._announced = False
+
+    def clear(self):
+        """Clears the active rate limit."""
+        with self._lock:
+            self._retry_at = 0.0
+            self._announced = False
+
+    @staticmethod
+    def _parse_retry_after(retry_after: str | int | None) -> int:
+        """Returns the number of seconds to wait from a `Retry-After`
+        value, falling back to the default when unusable."""
+        try:
+            seconds = int(str(retry_after).strip())
+        except (TypeError, ValueError):
+            LOGGER.debug(
+                "Unusable Retry-After value `%s`. Using the default of "
+                "%d s",
+                retry_after,
+                DEFAULT_RETRY_AFTER,
+            )
+            return DEFAULT_RETRY_AFTER
+
+        return max(0, seconds)
+
+
+RATE_LIMIT_GUARD = RateLimitGuard()

--- a/custom_components/spotcast/system_health.py
+++ b/custom_components/spotcast/system_health.py
@@ -13,6 +13,7 @@ from custom_components.spotcast import __version__
 from .chromecast import SpotifyController
 from .const import DOMAIN
 from .spotify.account import SpotifyAccount
+from .spotify.rate_limit import RATE_LIMIT_GUARD
 from .sessions import (
     PublicSession,
 )
@@ -41,6 +42,14 @@ async def system_health_info(hass: HomeAssistant) -> dict[str]:
         hass,
         f"https://{SpotifyController.APP_HOSTNAME}/",
     )
+
+    if RATE_LIMIT_GUARD.is_limited:
+        health_info["Rate Limit"] = {
+            "type": "failed",
+            "error": f"limited until {RATE_LIMIT_GUARD.resume_time}",
+        }
+    else:
+        health_info["Rate Limit"] = "ok"
 
     # accounts are numbered instead of named: system health ends up in
     # public bug reports and must not leak Spotify usernames or ids

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -444,8 +444,7 @@ Loggers surfaced in diagnostics: `spotipy`, `pychromecast`.
   failures and reports `UpstreamServerNotready` instead of retry storms.
 - **spotipy's fake 429.** When its urllib3 retries run out, `spotipy`
   raises `SpotifyException(429, -1, "... Max Retries")` **regardless of
-  the real HTTP status**, and its retry logger prints a "rate/request
-  limit" warning for any retried status (429/500/502/503/504)
+  the real HTTP status**
   ([spotipy-dev/spotipy#805](https://github.com/spotipy-dev/spotipy/issues/805)).
   The real status hides in `exc.reason` (urllib3 wording, e.g. "too many
   502 error responses"), and a genuine 429 always carries a `Retry-After`
@@ -458,7 +457,14 @@ Loggers surfaced in diagnostics: `spotipy`, `pychromecast`.
   account shares. spotipy's default retry would sleep the full
   `Retry-After` (urllib3 caps it at 6 hours) inside the executor thread,
   up to 3 times, per call. The extended client (`spotify/client.py`)
-  removes 429 from spotipy's retry codes and consults a shared
+  builds its own requests session (`_build_session`) with 429 removed
+  from the retry codes **and** `respect_retry_after_header=False`:
+  urllib3 retries any 429/503 carrying `Retry-After` when that flag is
+  set, regardless of `status_forcelist`, and spotipy's session builder
+  gives no way to turn it off. Server errors keep spotipy's 3 retries
+  with a short exponential backoff (the urllib3 `Retry` replaces
+  spotipy's subclass, so its misleading "rate/request limit" warning on
+  5xx retries is gone). The client then consults a shared
   `RateLimitGuard` (`spotify/rate_limit.py`) before every request: a
   429 registers `Retry-After` (default 30 s when missing) and raises
   `RateLimitedError`; until the window expires every client fails fast

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -450,10 +450,22 @@ Loggers surfaced in diagnostics: `spotipy`, `pychromecast`.
   The real status hides in `exc.reason` (urllib3 wording, e.g. "too many
   502 error responses"), and a genuine 429 always carries a `Retry-After`
   header. The coordinator matches that signature
-  (`SERVER_ERROR_PATTERN` in `coordinator.py`) and reports "Spotify API
+  (`SERVER_ERROR_PATTERN` in `spotify/client.py`) and reports "Spotify API
   temporarily unavailable (server errors)" instead of echoing the
   misleading 429. Do not trust a 429 status from a retry-exhausted
   spotipy call without checking `reason`.
+- **Genuine rate limits.** Spotify rate limits per client id, which every
+  account shares. spotipy's default retry would sleep the full
+  `Retry-After` (urllib3 caps it at 6 hours) inside the executor thread,
+  up to 3 times, per call. The extended client (`spotify/client.py`)
+  removes 429 from spotipy's retry codes and consults a shared
+  `RateLimitGuard` (`spotify/rate_limit.py`) before every request: a
+  429 registers `Retry-After` (default 30 s when missing) and raises
+  `RateLimitedError`; until the window expires every client fails fast
+  with the same error and no network call. `RateLimitedError` is a
+  `SpotifyException` (status 429) so existing handlers keep working; the
+  coordinator and the service handler special-case it to report the
+  resume time, and system health shows a `Rate Limit` row.
 - **Removed browse categories.** For Spotify applications created after
   2026-02-11, `GET /browse/categories` is gone with no replacement; the
   (deprecated) `spotcast/categories` WebSocket endpoint returns an empty

--- a/docs/config/spotcast_configuration.md
+++ b/docs/config/spotcast_configuration.md
@@ -98,6 +98,9 @@ Marks the account as the default Spotcast account, used by actions and WebSocket
 
 How often (in seconds) Spotcast refreshes the account data from Spotify: profile, available devices, playback state and library counts. Defaults to `30`, minimum `5`. Raise it if you want fewer calls to the Spotify API; lower it if you want playback state to react faster.
 
+> [!NOTE]
+> Spotify enforces its rate limit per application (client id), not per Spotify account. Every account configured in Spotcast shares the quota, and so does any other integration using the same application (for example the core Spotify integration). When Spotify answers with a rate limit, Spotcast pauses the API calls of all accounts until the `Retry-After` window expires and reports it in the logs and in **Settings > System > Repairs > System information**. If you run several accounts or hit the limit regularly, raise the refresh rate and give other integrations their own Spotify application.
+
 ### Days before removing unavailable devices
 
 A Spotify Connect device that disappears from the account (a phone that left the network, an ended [Jam](https://support.spotify.com/us/article/jam/) session) keeps its `media_player` entity for this many days before Spotcast removes the entity and its device registry entry. Defaults to `7`. Set it to `0` to remove devices as soon as they become unavailable.

--- a/test/coordinator/test_async_update_data.py
+++ b/test/coordinator/test_async_update_data.py
@@ -1,5 +1,6 @@
 """Module to test the _async_update_data function"""
 
+from time import time
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, AsyncMock
 
@@ -14,6 +15,7 @@ from custom_components.spotcast.media_player.device_manager import (
     DeviceManager,
 )
 from custom_components.spotcast.spotify import SpotifyAccount
+from custom_components.spotcast.spotify.exceptions import RateLimitedError
 
 
 class TestSuccessfulUpdate(IsolatedAsyncioTestCase):
@@ -253,3 +255,51 @@ class TestRetryExhaustedRateLimit(IsolatedAsyncioTestCase):
             "Could not refresh Spotify data for entry `12345`",
             str(context.exception),
         )
+
+
+class TestRateLimited(IsolatedAsyncioTestCase):
+    """A rate limit pauses every account: the refresh fails fast and
+    the message says when it resumes."""
+
+    async def asyncSetUp(self):
+
+        self.mocks = {
+            "hass": MagicMock(spec=HomeAssistant),
+            "entry": MagicMock(spec=ConfigEntry),
+            "account": MagicMock(spec=SpotifyAccount),
+        }
+
+        self.mocks["entry"].entry_id = "12345"
+        self.mocks["account"].entry_id = "12345"
+        self.mocks["account"].base_refresh_rate = 30
+
+        self.mocks["account"].async_profile.side_effect = RateLimitedError(
+            time() + 600,
+            "me",
+        )
+
+        self.mocks["hass"].data = {}
+
+        self.coordinator = SpotcastCoordinator(
+            self.mocks["hass"],
+            self.mocks["entry"],
+            self.mocks["account"],
+        )
+
+    async def test_update_failed_raised(self):
+        with self.assertRaises(UpdateFailed):
+            await self.coordinator._async_update_data()
+
+    async def test_message_reports_the_pause(self):
+        with self.assertRaises(UpdateFailed) as context:
+            await self.coordinator._async_update_data()
+
+        self.assertIn("rate limit active", str(context.exception))
+        self.assertIn("paused for", str(context.exception))
+        self.assertIn("`12345`", str(context.exception))
+
+    async def test_remaining_datasets_not_refreshed(self):
+        with self.assertRaises(UpdateFailed):
+            await self.coordinator._async_update_data()
+
+        self.mocks["account"].async_devices.assert_not_called()

--- a/test/services/service_handler/test_async_relay_service_call.py
+++ b/test/services/service_handler/test_async_relay_service_call.py
@@ -1,5 +1,6 @@
 """Module to test the async_relay_service_call"""
 
+from time import time
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -8,8 +9,10 @@ from urllib3.exceptions import ReadTimeoutError
 from custom_components.spotcast.services.service_handler import (
     ServiceHandler,
     HomeAssistant,
+    HomeAssistantError,
     ServiceCall,
     UnknownServiceError,
+    RateLimitedError,
     SERVICE_HANDLERS
 )
 
@@ -86,3 +89,25 @@ class TestErrorDuringServiceCall(IsolatedAsyncioTestCase):
             self.mock_log.assert_called_with(self.error)
         except AssertionError:
             self.fail()
+
+
+class TestRateLimitedDuringServiceCall(IsolatedAsyncioTestCase):
+    """A rate limit must surface to the user as an actionable error,
+    not a traceback."""
+
+    mock_play = AsyncMock()
+
+    @patch(f"{TEST_MODULE}.SERVICE_HANDLERS", {"play_media": mock_play})
+    async def test_home_assistant_error_raised(self):
+
+        hass = MagicMock(spec=HomeAssistant)
+        call = MagicMock(spec=ServiceCall)
+        call.service = "play_media"
+        self.mock_play.side_effect = RateLimitedError(time() + 300)
+        handler = ServiceHandler(hass)
+
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await handler.async_relay_service_call(call)
+
+        self.assertIn("rate limiting", str(ctx.exception))
+        self.assertIn("Try again in", str(ctx.exception))

--- a/test/spotify/account/test_async_play_media.py
+++ b/test/spotify/account/test_async_play_media.py
@@ -15,6 +15,8 @@ from custom_components.spotcast.spotify.account import (
     Store,
 )
 
+from custom_components.spotcast.spotify.exceptions import RateLimitedError
+
 from test.spotify.account import TEST_MODULE
 
 
@@ -460,3 +462,56 @@ class TestPlaybackError(IsolatedAsyncioTestCase):
                 "foo",
                 "spotify:dummy:uri"
             )
+
+
+class TestRateLimitedPlayback(IsolatedAsyncioTestCase):
+    """A rate limit is not a playback failure: the error keeps its
+    resume time so the service layer can tell the user when to retry."""
+
+    @patch(f"{TEST_MODULE}.Store", spec=Store, new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.Spotify", spec=Spotify, new_callable=MagicMock)
+    async def asyncSetUp(
+            self,
+            mock_spotify: MagicMock,
+            mock_store: MagicMock,
+    ):
+
+        self.mocks = {
+            "internal": MagicMock(spec=DesktopSession),
+            "external": MagicMock(spec=PublicSession),
+            "hass": MagicMock(spec=HomeAssistant),
+        }
+        self.mocks["hass"].loop = MagicMock()
+
+        self.mocks["external"].token = {
+            "access_token": "12345",
+            "expires_at": 12345.61,
+        }
+
+        self.account = SpotifyAccount(
+            entry_id="12345",
+            hass=self.mocks["hass"],
+            public_session=self.mocks["external"],
+            private_session=self.mocks["internal"],
+            is_default=True
+        )
+
+        self.account.async_ensure_tokens_valid = AsyncMock()
+
+        self.account._datasets["profile"].expires_at = time() + 9999
+        self.account._datasets["profile"]._data = {"name": "Dummy"}
+
+        self.mocks["hass"].async_add_executor_job = AsyncMock()
+        self.mocks["hass"].async_add_executor_job\
+            .side_effect = RateLimitedError(time() + 300)
+
+    async def test_start_playback_not_wrapped(self):
+        with self.assertRaises(RateLimitedError):
+            await self.account.async_play_media(
+                "foo",
+                "spotify:dummy:uri"
+            )
+
+    async def test_transfer_playback_not_wrapped(self):
+        with self.assertRaises(RateLimitedError):
+            await self.account.async_play_media("foo")

--- a/test/spotify/test_client.py
+++ b/test/spotify/test_client.py
@@ -1,5 +1,9 @@
 """Module to test the extended spotipy client"""
 
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from time import monotonic
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -305,3 +309,87 @@ class TestRateLimitOnUnauthorizedRetry(TestCase):
 
         self.assertTrue(guard.is_limited)
         self.assertEqual(mock_call.call_count, 2)
+
+
+class FakeSpotifyHandler(BaseHTTPRequestHandler):
+    """Answers like api.spotify.com does during a rate limit."""
+
+    queue: list[int] = []
+    hits = 0
+
+    def log_message(self, *_):
+        pass
+
+    def do_GET(self):
+        FakeSpotifyHandler.hits += 1
+        status = FakeSpotifyHandler.queue.pop(0)
+        body = json.dumps(
+            {"error": {"status": status, "message": "nope"}}
+            if status >= 400 else {"devices": []}
+        ).encode()
+        self.send_response(status)
+        if status == 429:
+            self.send_header("Retry-After", "3")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class TestRealStackRateLimit(TestCase):
+    """Through the real requests/urllib3 stack, a 429 with Retry-After
+    must come back immediately: urllib3 retries any 429 carrying the
+    header when respect_retry_after_header is set, regardless of
+    status_forcelist, so the session must be built without it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), FakeSpotifyHandler)
+        Thread(target=cls.server.serve_forever, daemon=True).start()
+        cls.prefix = f"http://127.0.0.1:{cls.server.server_port}/v1/"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def setUp(self):
+        FakeSpotifyHandler.hits = 0
+        self.guard = RateLimitGuard()
+        self.client = Spotify(
+            auth="dummy",
+            rate_limit_guard=self.guard,
+            requests_timeout=5,
+        )
+        self.client.prefix = self.prefix
+        self.addCleanup(self.client._session.close)
+
+    def test_429_not_retried_nor_slept(self):
+        FakeSpotifyHandler.queue = [429, 429, 429, 429]
+
+        start = monotonic()
+        with self.assertRaises(RateLimitedError):
+            self.client.devices()
+
+        self.assertLess(monotonic() - start, 1.0)
+        self.assertEqual(FakeSpotifyHandler.hits, 1)
+        self.assertAlmostEqual(self.guard.seconds_remaining, 3, delta=1)
+
+    def test_server_errors_still_retried(self):
+        FakeSpotifyHandler.queue = [502, 503, 200]
+
+        result = self.client.devices()
+
+        self.assertEqual(result, {"devices": []})
+        self.assertEqual(FakeSpotifyHandler.hits, 3)
+        self.assertFalse(self.guard.is_limited)
+
+    def test_exhausted_server_errors_not_a_rate_limit(self):
+        FakeSpotifyHandler.queue = [502, 502, 502, 502]
+
+        with self.assertRaises(SpotifyException) as ctx:
+            self.client.devices()
+
+        self.assertNotIsInstance(ctx.exception, RateLimitedError)
+        self.assertIn("502", str(ctx.exception.reason))
+        self.assertFalse(self.guard.is_limited)

--- a/test/spotify/test_client.py
+++ b/test/spotify/test_client.py
@@ -5,7 +5,15 @@ from unittest.mock import MagicMock, patch
 
 from spotipy import Spotify as SpotipyClient
 
-from custom_components.spotcast.spotify.client import Spotify, SpotifyException
+from custom_components.spotcast.spotify.client import (
+    Spotify,
+    SpotifyException,
+    RateLimitedError,
+)
+from custom_components.spotcast.spotify.rate_limit import (
+    RateLimitGuard,
+    DEFAULT_RETRY_AFTER,
+)
 
 CALL_ARGS = ("GET", "me/player/devices", None, {})
 
@@ -145,3 +153,155 @@ class TestOtherErrorNotRetried(TestCase):
 
         self.assertEqual(mock_call.call_count, 1)
         refresher.assert_not_called()
+
+
+def rate_limited(retry_after: str | None = "120") -> SpotifyException:
+    """Builds the exception spotipy raises on a 429."""
+    headers = {"Retry-After": retry_after} if retry_after else {}
+    return SpotifyException(
+        429,
+        -1,
+        "url:\n API rate limit exceeded",
+        headers=headers,
+    )
+
+
+class TestRateLimitRetriesDisabled(TestCase):
+    """spotipy must not sleep on a 429 inside the executor thread."""
+
+    def test_429_not_in_retry_codes(self):
+        client = Spotify(auth="dummy")
+        self.assertNotIn(429, client.status_forcelist)
+
+    def test_server_errors_still_retried(self):
+        client = Spotify(auth="dummy")
+        for code in (500, 502, 503, 504):
+            self.assertIn(code, client.status_forcelist)
+
+    def test_explicit_forcelist_respected(self):
+        client = Spotify(auth="dummy", status_forcelist=(503,))
+        self.assertEqual(client.status_forcelist, (503,))
+
+
+class TestRateLimitResponse(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def setUp(self, mock_call: MagicMock):
+        self.mock_call = mock_call
+        self.mock_call.side_effect = rate_limited("120")
+
+        self.guard = RateLimitGuard()
+        self.client = Spotify(auth="dummy", rate_limit_guard=self.guard)
+
+        with self.assertRaises(RateLimitedError) as ctx:
+            self.client._internal_call(*CALL_ARGS)
+
+        self.error = ctx.exception
+
+    def test_window_registered_from_header(self):
+        self.assertTrue(self.guard.is_limited)
+        self.assertAlmostEqual(self.guard.seconds_remaining, 120, delta=2)
+
+    def test_error_carries_retry_at(self):
+        self.assertEqual(self.error.retry_at, self.guard.retry_at)
+
+    def test_error_is_a_spotify_exception(self):
+        self.assertIsInstance(self.error, SpotifyException)
+        self.assertEqual(self.error.http_status, 429)
+
+    def test_call_not_retried(self):
+        self.assertEqual(self.mock_call.call_count, 1)
+
+
+class TestRateLimitResponseWithoutHeader(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def test_default_window_registered(self, mock_call: MagicMock):
+        mock_call.side_effect = rate_limited(None)
+        guard = RateLimitGuard()
+        client = Spotify(auth="dummy", rate_limit_guard=guard)
+
+        with self.assertRaises(RateLimitedError):
+            client._internal_call(*CALL_ARGS)
+
+        self.assertTrue(guard.is_limited)
+        self.assertAlmostEqual(
+            guard.seconds_remaining,
+            DEFAULT_RETRY_AFTER,
+            delta=2,
+        )
+
+
+class TestCallSkippedWhileLimited(TestCase):
+    """Every client sharing the guard fails fast, without a network
+    call, until the window expires."""
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def setUp(self, mock_call: MagicMock):
+        self.mock_call = mock_call
+        self.guard = RateLimitGuard()
+        self.guard.register("120")
+
+        self.other_client = Spotify(auth="other", rate_limit_guard=self.guard)
+
+        with self.assertRaises(RateLimitedError):
+            self.other_client._internal_call(*CALL_ARGS)
+
+    def test_no_network_call_made(self):
+        self.mock_call.assert_not_called()
+
+
+class TestCallResumesAfterWindow(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def test_call_goes_through(self, mock_call: MagicMock):
+        mock_call.return_value = {"devices": []}
+        guard = RateLimitGuard()
+        guard.register("0")
+
+        client = Spotify(auth="dummy", rate_limit_guard=guard)
+        result = client._internal_call(*CALL_ARGS)
+
+        self.assertEqual(result, {"devices": []})
+        mock_call.assert_called_once()
+
+
+class TestFakeRateLimitOnServerErrors(TestCase):
+    """spotipy reports exhausted 5xx retries as a 429. Those are not a
+    rate limit and must not pause the other accounts."""
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def test_guard_not_triggered(self, mock_call: MagicMock):
+        mock_call.side_effect = SpotifyException(
+            429,
+            -1,
+            "url:\n Max Retries",
+            reason="too many 502 error responses",
+        )
+        guard = RateLimitGuard()
+        client = Spotify(auth="dummy", rate_limit_guard=guard)
+
+        with self.assertRaises(SpotifyException) as ctx:
+            client._internal_call(*CALL_ARGS)
+
+        self.assertNotIsInstance(ctx.exception, RateLimitedError)
+        self.assertFalse(guard.is_limited)
+
+
+class TestRateLimitOnUnauthorizedRetry(TestCase):
+
+    @patch.object(SpotipyClient, "_internal_call")
+    def test_429_on_retry_registered(self, mock_call: MagicMock):
+        mock_call.side_effect = [unauthorized(), rate_limited("90")]
+        guard = RateLimitGuard()
+        client = Spotify(
+            auth="stale",
+            token_refresher=MagicMock(return_value="fresh"),
+            rate_limit_guard=guard,
+        )
+
+        with self.assertRaises(RateLimitedError):
+            client._internal_call(*CALL_ARGS)
+
+        self.assertTrue(guard.is_limited)
+        self.assertEqual(mock_call.call_count, 2)

--- a/test/spotify/test_rate_limit.py
+++ b/test/spotify/test_rate_limit.py
@@ -1,0 +1,148 @@
+"""Module to test the shared rate limit guard"""
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from custom_components.spotcast.spotify.rate_limit import (
+    RateLimitGuard,
+    RateLimitedError,
+    DEFAULT_RETRY_AFTER,
+)
+
+TEST_MODULE = "custom_components.spotcast.spotify.rate_limit"
+
+
+class TestRegisterWithHeader(TestCase):
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def setUp(self, mock_time):
+        self.guard = RateLimitGuard()
+        self.result = self.guard.register("2484")
+
+    def test_retry_at_set_from_header(self):
+        self.assertEqual(self.guard.retry_at, 3484.0)
+
+    def test_retry_at_returned(self):
+        self.assertEqual(self.result, 3484.0)
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_guard_is_limited(self, mock_time):
+        self.assertTrue(self.guard.is_limited)
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_seconds_remaining(self, mock_time):
+        self.assertEqual(self.guard.seconds_remaining, 2485)
+
+
+class TestRegisterWithoutHeader(TestCase):
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_default_window_used(self, mock_time):
+        guard = RateLimitGuard()
+        guard.register(None)
+        self.assertEqual(guard.retry_at, 1000.0 + DEFAULT_RETRY_AFTER)
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_garbage_header_uses_default(self, mock_time):
+        guard = RateLimitGuard()
+        guard.register("Wed, 21 Oct 2015 07:28:00 GMT")
+        self.assertEqual(guard.retry_at, 1000.0 + DEFAULT_RETRY_AFTER)
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_negative_header_clamped(self, mock_time):
+        guard = RateLimitGuard()
+        guard.register("-5")
+        self.assertEqual(guard.retry_at, 1000.0)
+
+
+class TestRegisterNeverShortens(TestCase):
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_later_window_kept(self, mock_time):
+        guard = RateLimitGuard()
+        guard.register("600")
+        guard.register("60")
+        self.assertEqual(guard.retry_at, 1600.0)
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_longer_window_extends(self, mock_time):
+        guard = RateLimitGuard()
+        guard.register("60")
+        guard.register("600")
+        self.assertEqual(guard.retry_at, 1600.0)
+
+
+class TestCheck(TestCase):
+
+    def setUp(self):
+        self.guard = RateLimitGuard()
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_passes_when_not_limited(self, mock_time):
+        try:
+            self.guard.check()
+        except RateLimitedError:
+            self.fail()
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_raises_while_limited(self, mock_time):
+        self.guard.register("60")
+
+        with self.assertRaises(RateLimitedError) as ctx:
+            self.guard.check()
+
+        self.assertEqual(ctx.exception.retry_at, 1060.0)
+        self.assertEqual(ctx.exception.http_status, 429)
+
+    @patch(f"{TEST_MODULE}.time")
+    def test_passes_after_window(self, mock_time):
+        mock_time.return_value = 1000.0
+        self.guard.register("60")
+
+        mock_time.return_value = 1061.0
+
+        try:
+            self.guard.check()
+        except RateLimitedError:
+            self.fail()
+
+        self.assertFalse(self.guard.is_limited)
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_clear_lifts_the_limit(self, mock_time):
+        self.guard.register("60")
+        self.guard.clear()
+
+        self.assertFalse(self.guard.is_limited)
+        self.assertEqual(self.guard.retry_at, 0.0)
+
+
+class TestLogging(TestCase):
+
+    @patch(f"{TEST_MODULE}.time", return_value=1000.0)
+    def test_warning_only_once_per_window(self, mock_time):
+        guard = RateLimitGuard()
+
+        with self.assertLogs(TEST_MODULE, level="DEBUG") as logs:
+            guard.register("60")
+            guard.register("60")
+            guard.register("60")
+
+        levels = [record.levelname for record in logs.records]
+        self.assertEqual(levels.count("WARNING"), 1)
+        self.assertEqual(levels.count("DEBUG"), 2)
+
+    @patch(f"{TEST_MODULE}.time")
+    def test_warning_again_after_window_expired(self, mock_time):
+        guard = RateLimitGuard()
+
+        mock_time.return_value = 1000.0
+        guard.register("60")
+
+        mock_time.return_value = 1061.0
+        guard.check()
+
+        with self.assertLogs(TEST_MODULE, level="WARNING") as logs:
+            guard.register("60")
+
+        self.assertEqual(len(logs.records), 1)

--- a/test/system_health/test_system_health_info.py
+++ b/test/system_health/test_system_health_info.py
@@ -96,3 +96,30 @@ class TestUnHealthyAccount(IsolatedAsyncioTestCase):
             self.result["Account 1 Public Token"],
             {"type": "failed", "error": "unhealthy"},
         )
+
+
+class TestRateLimitRow(IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.hass = MagicMock(spec=HomeAssistant)
+        self.hass.data = {"spotcast": {}}
+
+    @patch(f"{TEST_MODULE}.async_check_can_reach_url", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.RATE_LIMIT_GUARD")
+    async def test_ok_when_not_limited(self, guard: MagicMock, _: MagicMock):
+        guard.is_limited = False
+        result = await system_health_info(self.hass)
+
+        self.assertEqual(result["Rate Limit"], "ok")
+
+    @patch(f"{TEST_MODULE}.async_check_can_reach_url", new_callable=MagicMock)
+    @patch(f"{TEST_MODULE}.RATE_LIMIT_GUARD")
+    async def test_failed_when_limited(self, guard: MagicMock, _: MagicMock):
+        guard.is_limited = True
+        guard.resume_time = "12:34:56"
+        result = await system_health_info(self.hass)
+
+        self.assertEqual(
+            result["Rate Limit"],
+            {"type": "failed", "error": "limited until 12:34:56"},
+        )


### PR DESCRIPTION
Fixes #68

## Problem

`Spotify()` was built with spotipy's defaults, which retry a `429` through urllib3's `Retry` with `respect_retry_after_header=True`. That means `time.sleep(Retry-After)` (capped at 6 h by urllib3) **inside the Home Assistant executor thread**, up to 3 times, for every call that gets a 429. With the reporter's `Retry-After` values (2,484 s to 12,471 s) a single coordinator refresh or `play_media` call could hang for hours, once per account, and nothing in spotcast read `Retry-After` or told the other accounts (same client id, same rate limit) to stop.

## Fix

- `spotify/client.py`: remove 429 from spotipy's `status_forcelist` (5xx retries unchanged, the fake-429-on-5xx unmasking moved here as `SERVER_ERROR_PATTERN` / `is_rate_limit()`), and consult a shared `RateLimitGuard` before every request. A genuine 429 registers `Retry-After` (default 30 s when missing, never shortens an existing window) and raises `RateLimitedError`; until the window expires every client fails fast with no network call, then resumes on its own.
- `spotify/rate_limit.py` (new): thread-safe guard, one WARNING per window then DEBUG.
- `spotify/exceptions.py`: `RateLimitedError(SpotifyException)` with status 429, `retry_at`, `seconds_remaining`, `resume_time`, so existing `except SpotifyException` paths keep working.
- `coordinator.py`: "Spotify rate limit active for this client id. Refresh of entry `...` paused for N s (until HH:MM:SS)".
- `services/service_handler.py`: `HomeAssistantError("Spotify is rate limiting this client id. Try again in N s (after HH:MM:SS)")` instead of a traceback.
- `spotify/account/playback.py`: `RateLimitedError` passes through the `PlaybackError` wrappers (device-not-found retry extracted into `_async_retry_when_device_appears`).
- `system_health.py`: `Rate Limit` row (`ok` / `limited until HH:MM:SS`).
- Docs note on the per-client-id quota, changelog entry.

## Tests

35 new tests (guard, client, coordinator, service handler, playback, system health). `task test`: 791 passed. `pylint custom_components`: 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
