### PR TITLE
Release v6.6.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.6.1
+current_version = 6.6.2
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[^\d]*)(?P<build>\d+))?
 serialize = 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This repository is the continuation of the original [fondberg/spotcast](https://github.com/fondberg/spotcast) project. For the history of releases prior to v6, see the [original project's releases](https://github.com/fondberg/spotcast/releases). Releases v6.3.0 through v6.5.2 are documented in the [GitHub release notes](https://github.com/Mincka/spotcast/releases).
 
-## Unreleased
+## v6.6.2 (2026-09-07)
 
 ### Fixes
 

--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import DEFAULT_OPTIONS
 from .spotify import SpotifyAccount
 from .coordinator import SpotcastCoordinator
 
-__version__ = "6.6.1"
+__version__ = "6.6.2"
 
 
 LOGGER = getLogger(__name__)

--- a/custom_components/spotcast/manifest.json
+++ b/custom_components/spotcast/manifest.json
@@ -22,5 +22,5 @@
         "spotipy>=2.26.0",
         "RapidFuzz>=3.14.5"
     ],
-    "version": "6.6.1"
+    "version": "6.6.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spotcast"
-version = "6.6.1"
+version = "6.6.2"
 description = "Home Assistant custom component to start Spotify playback on an idle Chromecast or a Spotify Connect device. Meaning you can target automation for Chromecast as well as Spotify Connect devices."
 readme = "README.md"
 requires-python = ">=3.14.2"

--- a/uv.lock
+++ b/uv.lock
@@ -2420,7 +2420,7 @@ wheels = [
 
 [[package]]
 name = "spotcast"
-version = "6.6.1"
+version = "6.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "atomicwrites-homeassistant" },


### PR DESCRIPTION
## Description

Version bump to v6.6.2. Contents are in the CHANGELOG under v6.6.2 (2026-09-07):

- Fix: a cast to an unreachable or refusing Chromecast fails with a clear error instead of hanging the service call, and a credential refusal is reported with the device's own status (#67, #71).
- Project: dev lock on Home Assistant 2026.9.1, PyJWT override dropped, dependency audit clean.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)